### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -49,8 +49,8 @@ jobs:
             - name: PubSubClient
             - name: SHT31
             # LiquidCrystal I2C for ESP8266
-            - source-url: https://github.com/lucasmaziero/LiquidCrystal_I2C.git
-              verision: 1.1
+            - source-url: https://github.com/johnrickman/LiquidCrystal_I2C
+              verision: 1.1.3
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -48,9 +48,11 @@ jobs:
             - name: ArduinoJson
             - name: PubSubClient
             - name: SHT31
+            - name: LiquidCrystal_I2C
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git
+            - source-url: https://github.com/bertmelis/DHT
           sketch-paths: |
             # Compile these sketches for all boards
             - examples

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -52,7 +52,7 @@ jobs:
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git
-            - source-url: https://github.com/bertmelis/DHT
+            - source-url: https://github.com/bertmelis/DHT.git
           sketch-paths: |
             # Compile these sketches for all boards
             - examples

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -48,7 +48,9 @@ jobs:
             - name: ArduinoJson
             - name: PubSubClient
             - name: SHT31
-            - name: LiquidCrystal I2C
+            # LiquidCrystal I2C for ESP8266
+            - source-url: https://github.com/lucasmaziero/LiquidCrystal_I2C.git
+              verision: 1.1
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -49,8 +49,8 @@ jobs:
             - name: PubSubClient
             - name: SHT31
             # LiquidCrystal I2C for ESP8266
-            - source-url: https://github.com/johnrickman/LiquidCrystal_I2C
-              verision: 1.1.3
+            - source-url: https://github.com/johnrickman/LiquidCrystal_I2C.git
+              version: 1.1.3
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -48,7 +48,7 @@ jobs:
             - name: ArduinoJson
             - name: PubSubClient
             - name: SHT31
-            - name: LiquidCrystal_I2C
+            - name: LiquidCrystal I2C
             - source-url: https://github.com/me-no-dev/ESPAsyncWebServer.git
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git

--- a/.github/workflows/compile-examples.yaml
+++ b/.github/workflows/compile-examples.yaml
@@ -53,6 +53,7 @@ jobs:
             - source-url: https://github.com/me-no-dev/ESPAsyncTCP.git
             - source-url: https://github.com/grmcdorman/esp8266_web_settings.git
             - source-url: https://github.com/bertmelis/DHT.git
+              version: 1.0.1
           sketch-paths: |
             # Compile these sketches for all boards
             - examples

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 html
+.vscode/settings.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 grmcdorman
+Copyright (c) 2021, 2022 G. R. McDorman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ static void on_save(::grmcdorman::WebSettings &)
 There will be some other management around the `WebSettings` class, for things like reset and factory defaults callbacks. See the example for all the details. The example also includes OTA support (which, in theory, could also be a device, but it's simple enough that it's not needed).
 
 <h2>REST API</h2>
-An optional component provides a REST (stateless) web API. The API is created by declaring a [`WebServerRestAPI`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_web_server_rest_api.html) variable, initializing it with an `AsyncWebServer` instance, and adding the devices to create APIs for:
+An optional component provides a REST (stateless) web API. The API is created by declaring a [`WebServerRestAPI`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_web_server_rest_api.html) variable, and initializing it with an `AsyncWebServer` instance and the list of devices:
 
 ```
 static ::grmcdorman::device::WebServerRestApi rest_api;
@@ -159,8 +159,7 @@ void setup()
 {
     // other setup as required
 
-    rest_api.set_devices(devices);
-    rest_api.setup(webServer.get_server()); // or an instance of an AsyncWebServer
+    rest_api.setup(webServer.get_server(), devices); // or an instance of an AsyncWebServer
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ In addition, devices can easily publish to a MQTT server, provided the `MqttPubl
 
 The example provided in this repository is the actual working sketch I use for my own Ikea Vindriktning air quality sensor; I have added a SHT31-D to the setup. You may notice from the screen shots that a temperature offset is applied; it appears that either the sensor reads high by two to three degrees Celcius or the heat generated inside the Vindriktning case throws off the reading by that amount.
 
-At the moment, there are seven devices:
+Values reported by devices are the moving average of the last five readings; the most recent reading is also available.
+
+At the moment, there are ten devices:
+* [`BasicAnalog`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_basic_analog.html): A basic analog sensor, reading from the ESP8266 `A0` input. The reading is reported as floating-point; the reading can be transformed with a mulitpler and scale to give, for example, volts.
+* [`DhtSensor`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_dht_sensor.html): A DHT11 or DHT22 sensor, using Bert Melis' interrupt-driven DHT library (https://github.com/bertmelis/DHT).
 * [`InfoDisplay`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_info_display.html): When connected to a `WebSetting` instance, displays and updates basic system information:
   * Host name and IP address.
   * Connected access point
@@ -36,7 +40,8 @@ At the moment, there are seven devices:
   * Core version
   * Boot version
   * SDK version
-  * CPU frequencey
+  * CPU frequency
+* [`ThermistorSensor`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_thermistor_sensor.html): Reads analog values from the ESP8266 `A0` input and converts them to a temperature reading using the standard equations. The thermistor's thermal index, or Beta, and reference temperatures must be supplied; there are also some assumptions about the circuit wiring. See the documentation for the class, or the source, for details.
 * [`VindriktningAirQuality`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_vindriktning_air_quality.html): This monitors an Ikea Vindriktning air quality sensor. This class is derived from work by Hypfer's GitHub project, https://github.com/Hypfer/esp8266-vindriktning-particle-sensor. All work on message deciphering comes from that project.
 * [`WifiDisplay`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_wifi_display.html):  When connected to a `WebSetting` instance, displays and updates basic WiFi information:
   * Soft IP Address (if applicable)
@@ -69,14 +74,19 @@ Usage is generally pretty simple:
 
 * Create a vector (`std::vector<Device *>`) of devices, containing each of the devices you want to use, and declare a `WebSettings` and a `Config`:
 ```
-static std::vector<::grmcdorman::device::Device *> devices{
-    new ::grmcdorman::device::InfoDisplay,
-    new ::grmcdorman::device::SystemDetailsDisplay,
-    new ::grmcdorman::device::WifiDisplay,
-    new ::grmcdorman::device::WifiSetup,
-    new ::grmcdorman::device::Sht31Sensor,
-    new ::grmcdorman::device::VindriktningAirQuality,
-    new ::grmcdorman::device::MqttPublisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version))
+static ::grmcdorman::device::InfoDisplay info_display;
+static ::grmcdorman::device::SystemDetailsDisplay system_details_display;
+static ::grmcdorman::device::WifiDisplay wifi_display;
+static ::grmcdorman::device::WifiSetup wifi_setup;
+static ::grmcdorman::device::Sht31Sensor sht31_sensor;
+static ::grmcdorman::device::VindriktningAirQuality vindriktning_air_quality;static std::vector<::grmcdorman::device::Device *> devices{
+    &info_display,
+    &system_details_display,
+    &wifi_display,
+    &wifi_setup,
+    &sht31_sensor,
+    &vindriktning_air_quality,
+    &mqtt_publisher
 };
 static grmcdorman::device::ConfigFile config;
 static grmcdorman::WebSettings webServer;
@@ -91,17 +101,14 @@ static grmcdorman::WebSettings webServer;
 ```
 * Optionally, set some defaults different from the built-in ones:
 ```
-    // Device index # 0 is InfoDisplay. It has no relevant settings.
-    // Device index # 1 is System Details Display. It has no relevant settings.
-    // Device index # 2 is WiFi display. It has no relevant settings.
-    // Device index # 3 is the WiFi setup. A default AP and password could be set:
-    devices[3]->set("ssid", "my access point");
+    // Set a default SSID and password.
+    wifi_setup.set("ssid", "my access point");
     // Note that this will *not* be shown in the web page UI.
-    devices[3]->set("password", "my password");
+    wifi_setup.set("password", "my password");
 
-    // Device index # 4 is the SHT31-D. Set the default sda to D2, scl to D3.
-    devices[4]->set("sda", "D2");
-    devices[4]->set("scl", "D3");
+    // Set the default sda to D2, scl to D3.
+    sht31_sensor.set("sda", "D2");
+    sht31_sensor.set("scl", "D3");
 ```
 * Load and apply settings:
 ```
@@ -142,8 +149,27 @@ static void on_save(::grmcdorman::WebSettings &)
 
 There will be some other management around the `WebSettings` class, for things like reset and factory defaults callbacks. See the example for all the details. The example also includes OTA support (which, in theory, could also be a device, but it's simple enough that it's not needed).
 
+<h2>REST API</h2>
+An optional component provides a REST (stateless) web API. The API is created by declaring a [`WebServerRestAPI`](https://grmcdorman.github.io/esp8266_device_framework/classgrmcdorman_1_1device_1_1_web_server_rest_api.html) variable, initializing it with an `AsyncWebServer` instance, and adding the devices to create APIs for:
+
+```
+static ::grmcdorman::device::WebServerRestApi rest_api;
+// Declare devices as usual
+void setup()
+{
+    // other setup as required
+
+    rest_api.set_devices(devices);
+    rest_api.setup(webServer.get_server()); // or an instance of an AsyncWebServer
+}
+```
+
+That's it. Then the URLs `http://_your-server-name_/devices/get` and, for each device, `http://_your-server-ip_/device/_device-id_/get` to get the state for a device will be available.
+
+See the `RestApiExample.ino` for a complete working example, and `RestClientWithLDCExample.ino` for a working client that will display to a 2 row/16 column I2C LCD display.
+
 <h2>XHR/JavaScript requests</h2>
-The web settings server can be queried for device status via the `/settings/get` URL. The URL requires a query parameter that is the setting set identifier (which will be the device identifier if you follow the code layout above). The response is in JSON.
+The web settings server can be queried for device status via the `/settings/get` URL. The URL requires a query parameter that is the setting set identifier (which will be the device identifier if you follow the code layout above). The response is in JSON, and contains the text for the updatable UI fields.
 
 So, for example, the URL `/settings/get/?tab=system_overview` will return all the settings for the system overview tab:
 ```

--- a/examples/BasicAnalogExample/BasicAnalogExample.ino
+++ b/examples/BasicAnalogExample/BasicAnalogExample.ino
@@ -21,18 +21,12 @@
  */
 
 /*
- * This example includes the original seven devices:
- * - The InfoDisplay
- * - The MQTT publisher
- * - The SHT31-D sensor
- * - The System details display
- * - The Vindriktning Air Quality sensor
- * - The WiFi Display
- * - The WiFi setup
+ * This example uses the BasicAnalog device to collect ADC readings from the A0
+ * input. It will publish the reading in volts, with the assumption that the
+ * ADC reference voltage is 3.3V.
  */
 
 #include <ArduinoJson.h>
-#include <ArduinoOTA.h>
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>
 
@@ -44,34 +38,32 @@
 
 #include <grmcdorman/device/InfoDisplay.h>
 #include <grmcdorman/device/MqttPublisher.h>
-#include <grmcdorman/device/Sht31Sensor.h>
+#include <grmcdorman/device/BasicAnalog.h>
 #include <grmcdorman/device/SystemDetailsDisplay.h>
-#include <grmcdorman/device/VindriktningAirQuality.h>
 #include <grmcdorman/device/WifiDisplay.h>
 #include <grmcdorman/device/WifiSetup.h>
 
 
 // Global constant strings.
-static const char firmware_name[] PROGMEM = "esp8266-vindriktning-particle-sensor";
-static const char identifier_prefix[] PROGMEM = "VINDRIKTNING-";
+static const char firmware_name[] PROGMEM = "esp8266-analog-sensor";
+static const char identifier_prefix[] PROGMEM = "ESP8266-";
 static const char manufacturer[] PROGMEM = "grmcdorman";
 static const char model[] PROGMEM = "device_framework_example";
 static const char software_version[] PROGMEM = "1.1.0";
 
 // The default identifier string.
-static char identifier[sizeof ("VINDRIKTNING-") + 12];
+static char identifier[sizeof ("ESP8266-") + 12];
 
 // Our config file load/save and the web settings server.
 static grmcdorman::device::ConfigFile config;
 static grmcdorman::WebSettings webServer;
 
 // Device declarations. Order is not important.
-static ::grmcdorman::device::InfoDisplay info_display;
-static ::grmcdorman::device::SystemDetailsDisplay system_details_display;
-static ::grmcdorman::device::WifiDisplay wifi_display;
 static ::grmcdorman::device::WifiSetup wifi_setup;
-static ::grmcdorman::device::Sht31Sensor sht31_sensor;
-static ::grmcdorman::device::VindriktningAirQuality vindriktning_air_quality;
+
+static const char volts[] PROGMEM = "V";
+// This BasicAnalog device will report in volts. It is not configurable.
+static ::grmcdorman::device::BasicAnalog analog_sensor(FPSTR(volts), false, 3.3 / 1024.0, 0);
 
 // This uses the default WiFiClient for communications.
 static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version));
@@ -80,17 +72,12 @@ static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), F
 // Device list. Order _is_ important; this is the order they're presented on the web page.
 static std::vector<grmcdorman::device::Device *> devices
 {
-    &info_display,
-    &system_details_display,
-    &wifi_display,
+    &analog_sensor,
     &wifi_setup,
-    &sht31_sensor,
-    &vindriktning_air_quality,
     &mqtt_publisher
 };
 
 // State.
-static bool set_save_credentials = false;       //!< Set to true when credentials for save/restart etc. have been configured.
 static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
 static bool restart_next_loop = false;          //!< Set to true when a simple reset has been requested.
 static uint32_t restart_reset_when = 0;         //!< The time the factory reset/reset was requested.
@@ -115,17 +102,9 @@ void setup() {
 
     // Set some defaults.
 
-    // Device index # 0 is InfoDisplay. It has no relevant settings.
-    // Device index # 1 is System Details Display. It has no relevant settings.
-    // Device index # 2 is WiFi display. It has no relevant settings.
-    // Device index # 3 is the WiFi setup. A default AP and password could be set:
-    devices[3]->set("ssid", "my access point");
+    wifi_setup.set("ssid", "my access point");
     // Note that this will *not* be shown in the web page UI.
-    devices[3]->set("password", "my password");
-
-    // Device index # 4 is the SHT31-D. Set the default sda to D2, scl to D3.
-    devices[4]->set("sda", "D2");
-    devices[4]->set("scl", "D3");
+    wifi_setup.set("password", "my password");
 
     for (auto &device: devices)
     {
@@ -139,9 +118,7 @@ void setup() {
 
     // Print some device settings.
     Serial.print("WiFi SSID is ");
-    Serial.println(devices[3]->get("ssid"));
-    Serial.print("SHT31-D SDA is on pin ");
-    Serial.println(devices[4]->get("sda"));
+    Serial.println(wifi_setup.get("ssid"));
 
     for (auto &device : devices)
     {
@@ -150,70 +127,14 @@ void setup() {
         webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
     }
 
-    if (WiFi.isConnected())
-    {
-        // SoftAP capture portal clients are typically not happy about authentication.
-        webServer.set_credentials("admin", identifier);
-        set_save_credentials = true;
-        setupOTA();
-    }
-
     webServer.setup(on_save, on_restart, on_factory_reset);
 
     Serial.print(F("IP: "));
     Serial.println(WiFi.localIP().toString());
 }
 
-void setupOTA() {
-    ArduinoOTA.onStart([]() { Serial.println("Start"); });
-    ArduinoOTA.onEnd([]() { Serial.println("\nEnd"); });
-    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-    });
-    ArduinoOTA.onError([](ota_error_t error) {
-        Serial.printf("Error[%u]: ", error);
-        if (error == OTA_AUTH_ERROR) {
-            Serial.println("Auth Failed");
-        } else if (error == OTA_BEGIN_ERROR) {
-            Serial.println("Begin Failed");
-        } else if (error == OTA_CONNECT_ERROR) {
-            Serial.println("Connect Failed");
-        } else if (error == OTA_RECEIVE_ERROR) {
-            Serial.println("Receive Failed");
-        } else if (error == OTA_END_ERROR) {
-            Serial.println("End Failed");
-        }
-    });
-
-    // This needs a regular string.
-    ArduinoOTA.setHostname(String(WiFi.getHostname()).c_str());
-
-    // This could also be a setting
-    ArduinoOTA.setPassword(identifier);
-    ArduinoOTA.begin();
-}
-
 void loop()
 {
-    if (WiFi.isConnected())
-    {
-        if (!set_save_credentials)
-        {
-            // Connected to WiFi, but credentials for save/reset etc. were not set
-            webServer.set_credentials("admin", identifier);
-            set_save_credentials = true;
-        }
-    }
-    else if (WiFi.softAPgetStationNum() != 0)
-    {
-        if (set_save_credentials)
-        {
-            // In Soft AP mode with at least one client connected, and a password was set.
-            webServer.set_credentials(String(), String());
-        }
-    }
-
-    ArduinoOTA.handle();
     webServer.loop();
 
     for (auto &device : devices)

--- a/examples/DhtSensorExample/DhtSensorExample.ino
+++ b/examples/DhtSensorExample/DhtSensorExample.ino
@@ -21,14 +21,9 @@
  */
 
 /*
- * This example includes the original seven devices:
- * - The InfoDisplay
- * - The MQTT publisher
- * - The SHT31-D sensor
- * - The System details display
- * - The Vindriktning Air Quality sensor
- * - The WiFi Display
- * - The WiFi setup
+ * This example contains a DHT sensor, along with the MQTT Publish, and WifiSetup devices.
+ *
+ * The DHT can be configured as a DHT11 or DTH22; the default is a DHT11.
  */
 
 #include <ArduinoJson.h>
@@ -42,37 +37,27 @@
 
 #include <grmcdorman/device/ConfigFile.h>
 
-#include <grmcdorman/device/InfoDisplay.h>
 #include <grmcdorman/device/MqttPublisher.h>
-#include <grmcdorman/device/Sht31Sensor.h>
-#include <grmcdorman/device/SystemDetailsDisplay.h>
-#include <grmcdorman/device/VindriktningAirQuality.h>
-#include <grmcdorman/device/WifiDisplay.h>
+#include <grmcdorman/device/DhtSensor.h>
 #include <grmcdorman/device/WifiSetup.h>
 
-
 // Global constant strings.
-static const char firmware_name[] PROGMEM = "esp8266-vindriktning-particle-sensor";
-static const char identifier_prefix[] PROGMEM = "VINDRIKTNING-";
+static const char firmware_name[] PROGMEM = "esp8266-dht-sensor";
+static const char identifier_prefix[] PROGMEM = "ESP8266-";
 static const char manufacturer[] PROGMEM = "grmcdorman";
-static const char model[] PROGMEM = "device_framework_example";
+static const char model[] PROGMEM = "device_framework_example_dht";
 static const char software_version[] PROGMEM = "1.1.0";
 
 // The default identifier string.
-static char identifier[sizeof ("VINDRIKTNING-") + 12];
+static char identifier[sizeof ("ESP8266-") + 12];
 
 // Our config file load/save and the web settings server.
 static grmcdorman::device::ConfigFile config;
 static grmcdorman::WebSettings webServer;
 
 // Device declarations. Order is not important.
-static ::grmcdorman::device::InfoDisplay info_display;
-static ::grmcdorman::device::SystemDetailsDisplay system_details_display;
-static ::grmcdorman::device::WifiDisplay wifi_display;
 static ::grmcdorman::device::WifiSetup wifi_setup;
-static ::grmcdorman::device::Sht31Sensor sht31_sensor;
-static ::grmcdorman::device::VindriktningAirQuality vindriktning_air_quality;
-
+static ::grmcdorman::device::DhtSensor dht_sensor;
 // This uses the default WiFiClient for communications.
 static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version));
 
@@ -80,17 +65,12 @@ static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), F
 // Device list. Order _is_ important; this is the order they're presented on the web page.
 static std::vector<grmcdorman::device::Device *> devices
 {
-    &info_display,
-    &system_details_display,
-    &wifi_display,
+    &dht_sensor,
     &wifi_setup,
-    &sht31_sensor,
-    &vindriktning_air_quality,
     &mqtt_publisher
 };
 
 // State.
-static bool set_save_credentials = false;       //!< Set to true when credentials for save/restart etc. have been configured.
 static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
 static bool restart_next_loop = false;          //!< Set to true when a simple reset has been requested.
 static uint32_t restart_reset_when = 0;         //!< The time the factory reset/reset was requested.
@@ -115,17 +95,10 @@ void setup() {
 
     // Set some defaults.
 
-    // Device index # 0 is InfoDisplay. It has no relevant settings.
-    // Device index # 1 is System Details Display. It has no relevant settings.
-    // Device index # 2 is WiFi display. It has no relevant settings.
-    // Device index # 3 is the WiFi setup. A default AP and password could be set:
-    devices[3]->set("ssid", "my access point");
+    dht_sensor.set("dht_model", "DHT11");
+    //wifi_setup.set("ssid", "my access point");
     // Note that this will *not* be shown in the web page UI.
-    devices[3]->set("password", "my password");
-
-    // Device index # 4 is the SHT31-D. Set the default sda to D2, scl to D3.
-    devices[4]->set("sda", "D2");
-    devices[4]->set("scl", "D3");
+    //wifi_setup.set("password", "my password");
 
     for (auto &device: devices)
     {
@@ -139,9 +112,7 @@ void setup() {
 
     // Print some device settings.
     Serial.print("WiFi SSID is ");
-    Serial.println(devices[3]->get("ssid"));
-    Serial.print("SHT31-D SDA is on pin ");
-    Serial.println(devices[4]->get("sda"));
+    Serial.println(wifi_setup.get("ssid"));
 
     for (auto &device : devices)
     {
@@ -150,70 +121,15 @@ void setup() {
         webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
     }
 
-    if (WiFi.isConnected())
-    {
-        // SoftAP capture portal clients are typically not happy about authentication.
-        webServer.set_credentials("admin", identifier);
-        set_save_credentials = true;
-        setupOTA();
-    }
-
     webServer.setup(on_save, on_restart, on_factory_reset);
 
     Serial.print(F("IP: "));
     Serial.println(WiFi.localIP().toString());
 }
 
-void setupOTA() {
-    ArduinoOTA.onStart([]() { Serial.println("Start"); });
-    ArduinoOTA.onEnd([]() { Serial.println("\nEnd"); });
-    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-    });
-    ArduinoOTA.onError([](ota_error_t error) {
-        Serial.printf("Error[%u]: ", error);
-        if (error == OTA_AUTH_ERROR) {
-            Serial.println("Auth Failed");
-        } else if (error == OTA_BEGIN_ERROR) {
-            Serial.println("Begin Failed");
-        } else if (error == OTA_CONNECT_ERROR) {
-            Serial.println("Connect Failed");
-        } else if (error == OTA_RECEIVE_ERROR) {
-            Serial.println("Receive Failed");
-        } else if (error == OTA_END_ERROR) {
-            Serial.println("End Failed");
-        }
-    });
-
-    // This needs a regular string.
-    ArduinoOTA.setHostname(String(WiFi.getHostname()).c_str());
-
-    // This could also be a setting
-    ArduinoOTA.setPassword(identifier);
-    ArduinoOTA.begin();
-}
-
 void loop()
 {
-    if (WiFi.isConnected())
-    {
-        if (!set_save_credentials)
-        {
-            // Connected to WiFi, but credentials for save/reset etc. were not set
-            webServer.set_credentials("admin", identifier);
-            set_save_credentials = true;
-        }
-    }
-    else if (WiFi.softAPgetStationNum() != 0)
-    {
-        if (set_save_credentials)
-        {
-            // In Soft AP mode with at least one client connected, and a password was set.
-            webServer.set_credentials(String(), String());
-        }
-    }
 
-    ArduinoOTA.handle();
     webServer.loop();
 
     for (auto &device : devices)

--- a/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
+++ b/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * This example uses the DhtSensor to collect readings from a DHT11 or DHT22 sensor. As usual,
+ * the readings can be published to a MQTT server. However, the readings are also displayed
+ * on an attached LCD display of at least 2 rows and 16 columns.
+ *
+ * The LCD backlight is never turned off; you may want to add a button to control this.
+ *
+ * In addition to the basic libraries required by the device framework, this requires
+ * marcoschwartz/LiquidCrystal_I2C to be installed with your library manager.
+ */
+
+#include <ArduinoJson.h>
+#include <ArduinoOTA.h>
+#include <ESP8266WiFi.h>
+#include <LittleFS.h>
+#include <Wire.h>
+
+#include <LiquidCrystal_I2C.h>
+
+#include <esp8266_web_settings.h>
+
+#include <esp8266_device_framework.h>       // Required by the ESP compiler framework.
+
+#include <grmcdorman/device/ConfigFile.h>
+
+#include <grmcdorman/device/MqttPublisher.h>
+#include <grmcdorman/device/DhtSensor.h>
+#include <grmcdorman/device/WifiSetup.h>
+
+// Global constant strings.
+static const char firmware_name[] PROGMEM = "esp8266-dht-sensor";
+static const char identifier_prefix[] PROGMEM = "ESP8266-";
+static const char manufacturer[] PROGMEM = "grmcdorman";
+static const char model[] PROGMEM = "device_framework_example_dht";
+static const char software_version[] PROGMEM = "1.1.0";
+
+// A degree symbol for the LCD.
+static const byte degree[] PROGMEM = {
+  0x04,
+  0x0A,
+  0x04,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00
+};
+
+
+// The default identifier string.
+static char identifier[sizeof ("ESP8266-") + 12];
+
+// Our config file load/save and the web settings server.
+static grmcdorman::device::ConfigFile config;
+static grmcdorman::WebSettings webServer;
+
+// Device declarations. Order is not important.
+static ::grmcdorman::device::WifiSetup wifi_setup;
+static ::grmcdorman::device::DhtSensor dht_sensor;
+// This uses the default WiFiClient for communications.
+static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version));
+
+// This should be adjusted as per your LCD, or you can create configurable settings.
+static LiquidCrystal_I2C lcd(0x27, 16, 2);
+
+static Ticker lcd_update_ticker;
+
+// Device list. Order _is_ important; this is the order they're presented on the web page.
+static std::vector<grmcdorman::device::Device *> devices
+{
+    &dht_sensor,
+    &wifi_setup,
+    &mqtt_publisher
+};
+
+// State.
+static bool wifi_did_connect = false;
+
+static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
+static bool restart_next_loop = false;          //!< Set to true when a simple reset has been requested.
+static uint32_t restart_reset_when = 0;         //!< The time the factory reset/reset was requested.
+static constexpr uint32_t restart_reset_delay = 500;    //!< How long after the request for factory reset/reset to actually perform the function
+
+// Forward declarations for the three web_settings callbacks.
+
+static void on_factory_reset(::grmcdorman::WebSettings &);
+static void on_restart(::grmcdorman::WebSettings &);
+static void on_save(::grmcdorman::WebSettings &);
+
+static void lcd_report_wifi();
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println();
+    Serial.print(firmware_name);
+    Serial.println(" is starting");
+    Serial.flush();
+
+    strcpy_P(identifier, identifier_prefix);
+    itoa(ESP.getChipId(), identifier + strlen(identifier), 16);
+    Serial.print("My default identifier is ");
+    Serial.println(identifier);
+    Serial.flush();
+
+    // Set up the LCD.
+    Wire.begin(D2, D3);
+    lcd.init();
+
+    // While it is not essential to have this in PROGMEM, this
+    // code shows how to do so if you are tight on space or have
+    // lots of characters to set into the LCD. It also avoids
+    // the issue that the second argument to `createChar`
+    // is *not* const, and in theory could be overwritten.
+    byte char_matrix[sizeof(degree) / sizeof(degree[0])];
+    memcpy_P(char_matrix, degree, sizeof (degree));
+    lcd.createChar(1, char_matrix);
+
+    // Create characters for 'bars', from 1 to 4 at indices 2 to 5.
+    // There are 8 rows, so each level adds two rows.
+    memset(char_matrix, 0, sizeof(char_matrix));
+
+    for (int barLevel = 1; barLevel <= 4 ;++barLevel)
+    {
+        for (int row = 0; row < barLevel * 2; ++row)
+        {
+            char_matrix[7 - row] =   B11111;
+        }
+        lcd.createChar(barLevel + 1, char_matrix);
+    }
+
+    lcd.backlight();
+    lcd.setCursor(0, 0);
+    lcd.print("WiFi Connecting");
+
+    // At the moment there is no 'read' callback for the device; instead this will simply use a
+    // Ticker to update the LCD every so often.
+    lcd_update_ticker.attach_scheduled(5, [] {
+        lcd.setCursor(0, 1);
+        size_t col = 0;
+        col += lcd.print(dht_sensor.get_temperature());
+        col += lcd.print('\01');
+        col += lcd.print(' ');
+        col += lcd.print(dht_sensor.get_humidity());
+        col += lcd.print('%');
+        // Fill with spaces to the end of the 16 columns.
+        while (col < 16)
+        {
+            col += lcd.print(' ');
+        }
+        lcd_report_wifi();
+    });
+
+    // Set some defaults.
+    // Remember, these are *defaults*; loading the configuration
+    // will set them to the saved values, if the configuration file is present.
+    // This sets the DHT model as a DHT22. Obviously, if you have a DHT11
+    // set that, or don't make this call (the default is DHT11).
+    dht_sensor.set("dht_model", "DHT22");
+    Serial.println(dht_sensor.get("dht_model"));
+
+    for (auto &device: devices)
+    {
+        device->set_system_identifiers(FPSTR(firmware_name), identifier);
+        device->set_defaults();
+    }
+
+    // N.B. This will override the model set above if the settings are ever saved.
+    config.load(devices);
+
+    Serial.print("Configured DHT model is: ");
+    Serial.println(dht_sensor.get("dht_model"));
+
+    // If you wanted to override settings, you could call device 'set' methods here.
+
+    // Print some device settings.
+    Serial.print("WiFi SSID is ");
+    Serial.println(wifi_setup.get("ssid"));
+
+    for (auto &device : devices)
+    {
+        device->setup();
+        device->set_devices(devices);
+        webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
+    }
+
+    webServer.setup(on_save, on_restart, on_factory_reset);
+
+    Serial.print(F("IP: "));
+    Serial.println(WiFi.localIP().toString());
+}
+
+void loop()
+{
+
+    webServer.loop();
+
+    for (auto &device : devices)
+    {
+        if (device->is_enabled())
+        {
+            device->loop();
+        }
+    }
+
+    if (factory_reset_next_loop && millis() - restart_reset_when > restart_reset_delay)
+    {
+        // Clear file system.
+        LittleFS.format();
+        // Erase configuration
+        ESP.eraseConfig();
+        // Reset (not reboot, that may save current state)
+        ESP.reset();
+    }
+
+    if (restart_next_loop && millis() - restart_reset_when > restart_reset_delay)
+    {
+        ESP.restart();
+    }
+}
+
+static void on_factory_reset(::grmcdorman::WebSettings &)
+{
+    factory_reset_next_loop = true;
+    restart_reset_when = millis();
+}
+
+static void on_restart(::grmcdorman::WebSettings &)
+{
+    restart_next_loop =-true;
+    restart_reset_when = millis();
+}
+
+static void on_save(::grmcdorman::WebSettings &)
+{
+    config.save(devices);
+}
+
+static void lcd_report_wifi()
+{
+    if (WiFi.isConnected())
+    {
+        auto signal = WiFi.RSSI();
+        if (signal != 0)
+        {
+            int bars = 0;
+            static int lastBars = -1;
+            if (signal < -89 || signal == 0)
+            {
+                bars = 0;
+            }
+            else if (signal < -78)  // -78 to -88
+            {
+                bars = 1;
+            }
+            else if (signal < -67) // -67 to -77
+            {
+                bars = 2;
+            }
+            else if (signal < -56) // -56 to -66
+            {
+                bars = 3;
+            }
+            else // -55 or higher
+            {
+                bars = 4;
+            }
+            if (bars != lastBars)
+            {
+                lastBars = bars;
+                lcd.setCursor(0, 0);
+                if (bars == 0)
+                {
+                    lcd.print(' ');
+                }
+                else
+                {
+                    lcd.print(static_cast<char>(bars + 1));
+                }
+            }
+        }
+    }
+    if (!wifi_did_connect && WiFi.isConnected())
+    {
+        // Erase message.
+        lcd.setCursor(1, 0);
+        auto col = 1 + lcd.print(WiFi.localIP().toString());
+        while (col < 16)
+        {
+            lcd.print(' ');
+            ++col;
+        }
+        wifi_did_connect = true;
+    }
+
+}

--- a/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
+++ b/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
@@ -126,7 +126,7 @@ void setup() {
     Serial.flush();
 
     // Set up the LCD, I2C on D1/D2.
-    Wire.begin(D1, D2);
+    Wire.begin(5, 4);
     lcd.init();
 
     // While it is not essential to have this in PROGMEM, this

--- a/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
+++ b/examples/DhtSensorWithLCDExample/DhtSensorWithLCDExample.ino
@@ -31,6 +31,7 @@
  * marcoschwartz/LiquidCrystal_I2C to be installed with your library manager.
  */
 
+#include <Arduino.h>
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
 #include <ESP8266WiFi.h>
@@ -124,8 +125,8 @@ void setup() {
     Serial.println(identifier);
     Serial.flush();
 
-    // Set up the LCD.
-    Wire.begin(D2, D3);
+    // Set up the LCD, I2C on D1/D2.
+    Wire.begin(D1, D2);
     lcd.init();
 
     // While it is not essential to have this in PROGMEM, this

--- a/examples/RestApiExample/RestApiExample.ino
+++ b/examples/RestApiExample/RestApiExample.ino
@@ -21,14 +21,21 @@
  */
 
 /*
- * This example includes the original seven devices:
- * - The InfoDisplay
- * - The MQTT publisher
- * - The SHT31-D sensor
- * - The System details display
- * - The Vindriktning Air Quality sensor
- * - The WiFi Display
- * - The WiFi setup
+ * This example contains a DHT sensor, WifiSetup, InfoDisplay, SystemDetailsDisplay, and WifiDisplay devices.
+ * It does *not* contain a MQTT publisher; instead, the REST API server is configured.
+ *
+ * To query the REST APIs, start with http://_your device ip_/rest/devices/get. This will
+ * return a list of the devices available in JSON. In this case, the response will
+ * contain only two devices:
+ * `["dht","wifi_setup"]`
+ *
+ * The values for the devices are at http://_your device ip_/rest/device/_device_/get.
+ * For example, the DHT response will be like:
+ * `{"dht":{"enabled":true,"temperature":{"average":23.6,"last":23,"sample_count":5,"sample_age_ms":4017},"humidity":{"average":41.2,"last":41,"sample_count":5,"sample_age_ms":4017}}}`
+ * and the WiFi setup response will be like:
+ * `{"wifi_setup":{"enabled":true,"ssid":"myap","ip":"192.168.213.48","rssi":-46}}`.
+ *
+ * The DHT can be configured as a DHT11 or DTH22; the default is a DHT11.
  */
 
 #include <ArduinoJson.h>
@@ -42,55 +49,43 @@
 
 #include <grmcdorman/device/ConfigFile.h>
 
-#include <grmcdorman/device/InfoDisplay.h>
-#include <grmcdorman/device/MqttPublisher.h>
-#include <grmcdorman/device/Sht31Sensor.h>
 #include <grmcdorman/device/SystemDetailsDisplay.h>
-#include <grmcdorman/device/VindriktningAirQuality.h>
+#include <grmcdorman/device/InfoDisplay.h>
 #include <grmcdorman/device/WifiDisplay.h>
+#include <grmcdorman/device/DhtSensor.h>
 #include <grmcdorman/device/WifiSetup.h>
-
+#include <grmcdorman/device/WebServerRestAPI.h>
 
 // Global constant strings.
-static const char firmware_name[] PROGMEM = "esp8266-vindriktning-particle-sensor";
-static const char identifier_prefix[] PROGMEM = "VINDRIKTNING-";
+static const char firmware_name[] PROGMEM = "esp8266-dht-sensor";
+static const char identifier_prefix[] PROGMEM = "ESP8266-";
 static const char manufacturer[] PROGMEM = "grmcdorman";
-static const char model[] PROGMEM = "device_framework_example";
+static const char model[] PROGMEM = "device_framework_example_dht";
 static const char software_version[] PROGMEM = "1.1.0";
 
 // The default identifier string.
-static char identifier[sizeof ("VINDRIKTNING-") + 12];
+static char identifier[sizeof ("ESP8266-") + 12];
 
 // Our config file load/save and the web settings server.
 static grmcdorman::device::ConfigFile config;
 static grmcdorman::WebSettings webServer;
 
 // Device declarations. Order is not important.
-static ::grmcdorman::device::InfoDisplay info_display;
-static ::grmcdorman::device::SystemDetailsDisplay system_details_display;
-static ::grmcdorman::device::WifiDisplay wifi_display;
 static ::grmcdorman::device::WifiSetup wifi_setup;
-static ::grmcdorman::device::Sht31Sensor sht31_sensor;
-static ::grmcdorman::device::VindriktningAirQuality vindriktning_air_quality;
-
-// This uses the default WiFiClient for communications.
-static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version));
-
+static ::grmcdorman::device::DhtSensor dht_sensor;
+static ::grmcdorman::device::InfoDisplay info;
+static ::grmcdorman::device::SystemDetailsDisplay details;
+static ::grmcdorman::device::WifiDisplay wifi;
+static ::grmcdorman::device::WebServerRestApi rest_api;
 
 // Device list. Order _is_ important; this is the order they're presented on the web page.
 static std::vector<grmcdorman::device::Device *> devices
 {
-    &info_display,
-    &system_details_display,
-    &wifi_display,
-    &wifi_setup,
-    &sht31_sensor,
-    &vindriktning_air_quality,
-    &mqtt_publisher
+    &dht_sensor,
+    &wifi_setup, &info, &details, &wifi
 };
 
 // State.
-static bool set_save_credentials = false;       //!< Set to true when credentials for save/restart etc. have been configured.
 static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
 static bool restart_next_loop = false;          //!< Set to true when a simple reset has been requested.
 static uint32_t restart_reset_when = 0;         //!< The time the factory reset/reset was requested.
@@ -115,17 +110,10 @@ void setup() {
 
     // Set some defaults.
 
-    // Device index # 0 is InfoDisplay. It has no relevant settings.
-    // Device index # 1 is System Details Display. It has no relevant settings.
-    // Device index # 2 is WiFi display. It has no relevant settings.
-    // Device index # 3 is the WiFi setup. A default AP and password could be set:
-    devices[3]->set("ssid", "my access point");
+    dht_sensor.set("dht_model", "DHT11");
+    //wifi_setup.set("ssid", "my access point");
     // Note that this will *not* be shown in the web page UI.
-    devices[3]->set("password", "my password");
-
-    // Device index # 4 is the SHT31-D. Set the default sda to D2, scl to D3.
-    devices[4]->set("sda", "D2");
-    devices[4]->set("scl", "D3");
+    //wifi_setup.set("password", "my password");
 
     for (auto &device: devices)
     {
@@ -139,9 +127,7 @@ void setup() {
 
     // Print some device settings.
     Serial.print("WiFi SSID is ");
-    Serial.println(devices[3]->get("ssid"));
-    Serial.print("SHT31-D SDA is on pin ");
-    Serial.println(devices[4]->get("sda"));
+    Serial.println(wifi_setup.get("ssid"));
 
     for (auto &device : devices)
     {
@@ -150,13 +136,8 @@ void setup() {
         webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
     }
 
-    if (WiFi.isConnected())
-    {
-        // SoftAP capture portal clients are typically not happy about authentication.
-        webServer.set_credentials("admin", identifier);
-        set_save_credentials = true;
-        setupOTA();
-    }
+    rest_api.set_devices(devices);
+    rest_api.setup(webServer.get_server());
 
     webServer.setup(on_save, on_restart, on_factory_reset);
 
@@ -164,56 +145,9 @@ void setup() {
     Serial.println(WiFi.localIP().toString());
 }
 
-void setupOTA() {
-    ArduinoOTA.onStart([]() { Serial.println("Start"); });
-    ArduinoOTA.onEnd([]() { Serial.println("\nEnd"); });
-    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-    });
-    ArduinoOTA.onError([](ota_error_t error) {
-        Serial.printf("Error[%u]: ", error);
-        if (error == OTA_AUTH_ERROR) {
-            Serial.println("Auth Failed");
-        } else if (error == OTA_BEGIN_ERROR) {
-            Serial.println("Begin Failed");
-        } else if (error == OTA_CONNECT_ERROR) {
-            Serial.println("Connect Failed");
-        } else if (error == OTA_RECEIVE_ERROR) {
-            Serial.println("Receive Failed");
-        } else if (error == OTA_END_ERROR) {
-            Serial.println("End Failed");
-        }
-    });
-
-    // This needs a regular string.
-    ArduinoOTA.setHostname(String(WiFi.getHostname()).c_str());
-
-    // This could also be a setting
-    ArduinoOTA.setPassword(identifier);
-    ArduinoOTA.begin();
-}
-
 void loop()
 {
-    if (WiFi.isConnected())
-    {
-        if (!set_save_credentials)
-        {
-            // Connected to WiFi, but credentials for save/reset etc. were not set
-            webServer.set_credentials("admin", identifier);
-            set_save_credentials = true;
-        }
-    }
-    else if (WiFi.softAPgetStationNum() != 0)
-    {
-        if (set_save_credentials)
-        {
-            // In Soft AP mode with at least one client connected, and a password was set.
-            webServer.set_credentials(String(), String());
-        }
-    }
 
-    ArduinoOTA.handle();
     webServer.loop();
 
     for (auto &device : devices)

--- a/examples/RestApiExample/RestApiExample.ino
+++ b/examples/RestApiExample/RestApiExample.ino
@@ -136,8 +136,7 @@ void setup() {
         webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
     }
 
-    rest_api.set_devices(devices);
-    rest_api.setup(webServer.get_server());
+    rest_api.setup(webServer.get_server(), devices);
 
     webServer.setup(on_save, on_restart, on_factory_reset);
 

--- a/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
+++ b/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
@@ -1,0 +1,457 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * This example is a _client_ that connects to a Vindriktning+SHT31 ESP8266, retrieves the
+ * state, and displays the values - PM 2.5, temperature, humidity - on an LCD, along with
+ * the current uptime. The client must have the Rest API library enabled.
+ *
+ * The LCD is assumed to be a 2 row, 16 column device.
+ *
+ * The backlight turns off after 30 seconds. D1 is assumed to be connected to
+ * a button (or other trigger) to turn the backlight back on.
+ *
+ * The demo code from WebSettings has been adapted to provide the settings
+ * for entering a WiFi access point name and password, and the IP address
+ * (or host name) of your ESP8266-modified Vindriktning.
+ *
+ * If the target does not have a Vindriktning, or does not have a SHT31-D, the
+ * associated entries will show F:404 (i.e. not found).
+ *
+ * Additional libraries required:
+ *  - LiquidCrystal_I2C
+ */
+#include <Arduino.h>
+#include <Wire.h>
+#include <LiquidCrystal_I2C.h>
+#include <ArduinoJson.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266HTTPClient.h>
+#include <WiFiClient.h>
+#include <Ticker.h>
+#include <DNSServer.h>
+#include <LittleFS.h>
+
+#include <grmcdorman/WebSettings.h>
+
+// Forward declarations
+static void wifi_setup();
+static std::optional<DynamicJsonDocument> LoadConfig();
+static void on_save(::grmcdorman::WebSettings &);
+
+#define DECLARE_SETTING(name, text, type) \
+static const char * PROGMEM name##_text = text; \
+static const char * PROGMEM name##_id = #name; \
+static ::grmcdorman::type name(FPSTR(name##_text), FPSTR(name##_id));
+
+#define DECLARE_INFO_SETTING(name, text) DECLARE_SETTING(name, text, InfoSettingHtml)
+#define DECLARE_STRING_SETTING(name, text) DECLARE_SETTING(name, text, StringSetting)
+#define DECLARE_PASSWORD_SETTING(name, text) DECLARE_SETTING(name, text, PasswordSetting)
+#define DECLARE_TOGGLE_SETTING(name, text) DECLARE_SETTING(name, text, ToggleSetting)
+#define DECLARE_UNSIGNED_SETTING(name, text) DECLARE_SETTING(name, text, UnsignedIntegerSetting)
+
+DECLARE_INFO_SETTING(info, "ESP8266 Device REST Client Example");
+DECLARE_STRING_SETTING(ap_name, "WiFi Access Point");
+DECLARE_PASSWORD_SETTING(ap_password, "WiFi Password");
+DECLARE_STRING_SETTING(server_address, "Vindriktning Server Address");
+static ::grmcdorman::SettingInterface::settings_list_t
+        settings{&info, &ap_name, &ap_password, &server_address};
+
+static const char config_path[] PROGMEM = "/config.json";
+
+static LiquidCrystal_I2C lcd(0x27, 16, 2);
+static WiFiClient wifi_client;
+static HTTPClient http_client;
+static Ticker update_pm25_timer;
+static Ticker update_temperature_timer;
+static Ticker update_time_timer;
+static Ticker backlight_timer;
+static std::unique_ptr<DNSServer> dns_server;   //!< The DNS server for SoftAP mode.
+static grmcdorman::WebSettings web_settings;    //!< The settings web server. Default port (80).
+
+// Define some custom characters.
+static byte superscript3[] = {
+  0x18,
+  0x04,
+  0x18,
+  0x04,
+  0x18,
+  0x00,
+  0x00,
+  0x00
+};
+
+static byte mu[] = {
+  0x00,
+  0x00,
+  0x11,
+  0x11,
+  0x11,
+  0x13,
+  0x1D,
+  0x10
+};
+
+static byte degree[] = {
+  0x04,
+  0x0A,
+  0x04,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00
+};
+
+static void update_pm25();
+static void update_temperature();
+static void update_time();
+static void backlight_off();
+
+static constexpr auto expectedTemperaturePrintLength = sizeof("99d 99%") - 1;
+
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println("Begin LCD REST Client Demo");
+    Wire.begin(D2, D3);
+    lcd.init();
+    lcd.backlight();
+
+    lcd.setCursor(0, 0);
+    lcd.print("Initializing");
+    lcd.createChar(1, superscript3);
+    lcd.createChar(2, mu);
+    lcd.createChar(3, degree);
+    pinMode(D1, INPUT);
+
+    auto config = LoadConfig();
+    if (config)
+    {
+        for (auto &setting: settings)
+        {
+            if (setting->is_persistable() && !(*config)[setting->name()].isNull())
+            {
+                setting->set_from_string((*config)[setting->name()]);
+            }
+        }
+    }
+
+    // Apply loaded WiFi settings
+    wifi_setup();
+
+    // Add our one tab to the web server.
+    web_settings.add_setting_set(F("WiFi"), F("wifi_settings"), settings);
+    web_settings.setup(on_save, nullptr, nullptr);
+
+
+    update_pm25_timer.attach_scheduled(23, update_pm25);
+    update_temperature_timer.attach_scheduled(11, update_temperature);
+    update_time_timer.attach_scheduled(30, update_time);
+    backlight_timer.attach_scheduled(30, backlight_off);
+    http_client.setTimeout(5000);   // Timeout is in milliseconds.
+}
+
+void loop()
+{
+    // Handle DNS requests. This will make our captive portal work.
+    if (dns_server)
+    {
+        dns_server->processNextRequest();
+    }
+
+    // Not presently essential; might be needed in future.
+    web_settings.loop();
+
+
+    if (digitalRead(D1) == HIGH)
+    {
+        lcd.backlight();
+        backlight_timer.attach_scheduled(30, backlight_off);
+    }
+    static auto lastStatus = static_cast<decltype(WiFi.status())>(-1);
+
+    if (lastStatus != WiFi.status())
+    {
+        lcd.setCursor(0, 0);
+        update_time();
+        lastStatus = WiFi.status();
+        if (lastStatus == WL_CONNECTED)
+        {
+            //lcd.print( WiFi.localIP().toString());
+            update_temperature();
+            update_pm25();
+        }
+        else if (lastStatus == WL_CONNECT_FAILED)
+        {
+            lcd.print("Connection failed");
+        }
+    }
+}
+
+static void backlight_off()
+{
+    lcd.noBacklight();
+}
+
+static void update_time()
+{
+    if (WiFi.status() == WL_CONNECTED)
+    {
+        // If you use the NTPClient library or similar,
+        // this could be the actual time. Do not print seconds,
+        // that looks ugly on most LCD displays (too much refreshing).
+        lcd.setCursor(0, 0);
+        auto total_seconds = millis() / 1000;
+        auto minutes = (total_seconds / 60) % 60;
+        auto hours = (total_seconds / 60) / 60;
+        int col = 0;
+        if (hours < 10)
+        {
+            col += lcd.print(' ');
+        }
+        col += lcd.print(hours);
+        col += lcd.print(':');
+        if (minutes < 10)
+        {
+            col += lcd.print('0');
+        }
+        col += lcd.print(minutes);
+        while (col < 16)
+        {
+            col += lcd.print(' ');
+        }
+    }
+}
+
+static void update_temperature()
+{
+    if (WiFi.status() == WL_CONNECTED)
+    {
+        if (http_client.begin(wifi_client, "http://" + server_address.get() + "/rest/device/sht31_d/get"))
+        {
+            constexpr int startCol = 0;
+            constexpr int row = 1;
+            lcd.setCursor(startCol, row);
+            lcd.print("Get T");
+            auto status = http_client.GET();
+            lcd.setCursor(startCol, row);
+            size_t col = startCol;
+            if (status == 200)
+            {
+                DynamicJsonDocument doc(1024);
+                deserializeJson(doc, http_client.getStream());
+                auto temperature = doc["sht31_d"]["temperature"]["average"].as<float>();
+                auto humidity = doc["sht31_d"]["humidity"]["average"].as<float>();
+                col = lcd.print(static_cast<int>(temperature + 0.5));
+                col += lcd.print('\03');
+                col += lcd.print(' ');
+                col += lcd.print(static_cast<int>(humidity + 0.5));
+                col += lcd.print('%');
+            }
+            else if (status == HTTPC_ERROR_READ_TIMEOUT)
+            {
+                col = lcd.print("T/O");
+            }
+            else
+            {
+                col = lcd.print("F: ");
+                col += lcd.print(status);
+            }
+            http_client.end();
+            while (col < expectedTemperaturePrintLength + 1)
+            {
+                col += lcd.print(' ');
+            }
+        }
+        else
+        {
+            Serial.println("http_client begin failed");
+        }
+    }
+}
+
+
+static void update_pm25()
+{
+    if (WiFi.status() == WL_CONNECTED)
+    {
+        // Leave space for an actual time.
+        constexpr auto startCol = expectedTemperaturePrintLength + 1;
+        constexpr int row = 1;
+        if (http_client.begin(wifi_client, "http://" + server_address.get() + "/rest/device/vindriktning/get"))
+        {
+            lcd.setCursor(startCol, row);
+            size_t col = startCol;
+            lcd.print("PM25");
+            lcd.setCursor(startCol, row);
+            auto status = http_client.GET();
+            if (status == 200)
+            {
+                DynamicJsonDocument doc(1024);
+                deserializeJson(doc, http_client.getStream());
+                auto pm25 = doc["vindriktning"]["pm25"]["average"].as<float>();
+                col = startCol + lcd.print(static_cast<int>(pm25 + 0.5));
+                col += lcd.print("\02g/m\01");
+                while (col < 16)
+                {
+                    col += lcd.print(' ');
+                }
+            }
+            else if (status == HTTPC_ERROR_READ_TIMEOUT)
+            {
+                col = lcd.print("T/O");
+            }
+            else
+            {
+                col = lcd.print("F: ");
+                col += lcd.print(status);
+            }
+            http_client.end();
+            while (col < 16)
+            {
+                col += lcd.print(' ');
+            }
+        }
+        else
+        {
+            Serial.println("pm25 http_client begin failed");
+        }
+    }
+}
+
+// Set up WiFi.
+static void wifi_setup()
+{
+
+    if (!ap_name.get().isEmpty())
+    {
+        lcd.backlight();
+        lcd.setCursor(0, 0);
+        lcd.print("Connecting: ");
+        lcd.setCursor(0, 1);
+        lcd.print(ap_name.get().substring(0, 16));
+        // Do not use persistent WiFi settings, we manage those ourselves.
+        WiFi.persistent(false);
+        if (!WiFi.mode(WIFI_STA))
+        {
+            Serial.println(F("Warning: Unable to set STA mode"));
+        }
+
+        auto begin_status = WiFi.begin(ap_name.get(), ap_password.get());
+
+        if (!WiFi.config(0u, 0u, 0u))
+        {
+            Serial.println(F("Warning: Config for DHCP failed"));
+        }
+
+        auto status = WiFi.waitForConnectResult(30 * 1000);
+        if (status != WL_CONNECTED)
+        {
+            Serial.println(F("Unable to connect to the access point, status =") + String(status));
+        }
+    }
+
+    if (WiFi.status() != WL_CONNECTED)
+    {
+        // No SSID. Start in AP.
+        Serial.println(F("Starting in AP mode"));
+        lcd.setCursor(0, 0);
+        lcd.print("AP mode; SSID: ");
+#ifdef ESP8266
+// @bug workaround for bug #4372 https://github.com/esp8266/Arduino/issues/4372
+        WiFi.enableAP(true);
+        delay(500); // workaround delay
+#endif
+        WiFi.mode(WIFI_AP);
+        // "target_hostname" is the SSID.
+        WiFi.softAP(F("RestDemo") + String(ESP.getChipId(), 16));
+        delay(500);
+        Serial.print(F("Soft AP started at address "));
+        Serial.println(WiFi.softAPIP().toString());
+        dns_server = std::make_unique<DNSServer>();
+        dns_server->setErrorReplyCode(DNSReplyCode::NoError);
+        dns_server->start(53, "*", WiFi.softAPIP());
+        lcd.setCursor(0, 1);
+        lcd.print(WiFi.softAPSSID());
+    }
+
+    backlight_timer.attach_scheduled(30, backlight_off);
+}
+
+static std::optional<DynamicJsonDocument> LoadConfig()
+{
+
+    if (!LittleFS.begin()) {
+        return std::nullopt;
+    }
+
+    if (!LittleFS.exists(FPSTR(config_path))) {
+        return std::nullopt;
+    }
+
+    File configFile = LittleFS.open(FPSTR(config_path), "r");
+
+    if (!configFile) {
+        return std::nullopt;
+    }
+
+    DynamicJsonDocument json(configFile.size() * 10);
+
+    auto status = deserializeJson(json, configFile);
+    if (DeserializationError::Ok != status) {
+        Serial.print(F("Deserialization error: "));
+        Serial.println(status.c_str());
+        return std::nullopt;
+    }
+    return std::move(json);
+}
+
+static void on_save(::grmcdorman::WebSettings &)
+{
+    Serial.println("Saving settings");
+    DynamicJsonDocument json(4096);
+    for (auto &setting: settings)
+    {
+        if (strlen_P(reinterpret_cast<const char *>(setting->name())) != 0 && setting->is_persistable())
+        {
+            json[setting->name()] = setting->as_string();
+        }
+    }
+
+    File configFile = LittleFS.open(FPSTR(config_path), "w");
+    if (!configFile) {
+        return;
+    }
+
+    serializeJson(json, configFile);
+    configFile.close();
+
+    schedule_function([] {
+        if (!WiFi.isConnected())
+        {
+            WiFi.softAPdisconnect();
+            WiFi.enableAP(false);
+            wifi_setup();
+        }
+    });
+}

--- a/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
+++ b/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
@@ -51,7 +51,7 @@
 #include <DNSServer.h>
 #include <LittleFS.h>
 
-#include <grmcdorman/WebSettings.h>
+#include <esp8266_web_settings.h>
 
 // Forward declarations
 static void wifi_setup();
@@ -133,7 +133,7 @@ void setup()
 {
     Serial.begin(115200);
     Serial.println("Begin LCD REST Client Demo");
-    Wire.begin(D2, D3);
+    Wire.begin(D1, D2);
     lcd.init();
     lcd.backlight();
 

--- a/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
+++ b/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
@@ -133,7 +133,8 @@ void setup()
 {
     Serial.begin(115200);
     Serial.println("Begin LCD REST Client Demo");
-    Wire.begin(D1, D2);
+    // Begin Wire on D2, D3
+    Wire.begin(4, 0);
     lcd.init();
     lcd.backlight();
 
@@ -142,7 +143,7 @@ void setup()
     lcd.createChar(1, superscript3);
     lcd.createChar(2, mu);
     lcd.createChar(3, degree);
-    pinMode(D1, INPUT);
+    pinMode(5, INPUT);
 
     auto config = LoadConfig();
     if (config)

--- a/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
+++ b/examples/RestClientWithLDCExample/RestClientWithLDCExample.ino
@@ -184,7 +184,7 @@ void loop()
     web_settings.loop();
 
 
-    if (digitalRead(D1) == HIGH)
+    if (digitalRead(5) == HIGH)
     {
         lcd.backlight();
         backlight_timer.attach_scheduled(30, backlight_off);

--- a/examples/ThermistorExample/ThermistorExample.ino
+++ b/examples/ThermistorExample/ThermistorExample.ino
@@ -21,18 +21,14 @@
  */
 
 /*
- * This example includes the original seven devices:
- * - The InfoDisplay
- * - The MQTT publisher
- * - The SHT31-D sensor
- * - The System details display
- * - The Vindriktning Air Quality sensor
- * - The WiFi Display
- * - The WiFi setup
+ * This example uses the ThermistorSensor device to collect and publish thermistor readings.
+ * Correct the thermistor values to correspond to your thermistor.
  */
 
+static constexpr unsigned int THERMISTOR_THERMAL_INDEX = 3950;
+static constexpr float THERMISTOR_REFERENCE_TEMPERATURE_CELCIUS = 25;
+
 #include <ArduinoJson.h>
-#include <ArduinoOTA.h>
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>
 
@@ -42,36 +38,28 @@
 
 #include <grmcdorman/device/ConfigFile.h>
 
-#include <grmcdorman/device/InfoDisplay.h>
 #include <grmcdorman/device/MqttPublisher.h>
-#include <grmcdorman/device/Sht31Sensor.h>
-#include <grmcdorman/device/SystemDetailsDisplay.h>
-#include <grmcdorman/device/VindriktningAirQuality.h>
-#include <grmcdorman/device/WifiDisplay.h>
+#include <grmcdorman/device/ThermistorSensor.h>
 #include <grmcdorman/device/WifiSetup.h>
 
 
 // Global constant strings.
-static const char firmware_name[] PROGMEM = "esp8266-vindriktning-particle-sensor";
-static const char identifier_prefix[] PROGMEM = "VINDRIKTNING-";
+static const char firmware_name[] PROGMEM = "esp8266-analog-sensor";
+static const char identifier_prefix[] PROGMEM = "ESP8266-";
 static const char manufacturer[] PROGMEM = "grmcdorman";
 static const char model[] PROGMEM = "device_framework_example";
 static const char software_version[] PROGMEM = "1.1.0";
 
 // The default identifier string.
-static char identifier[sizeof ("VINDRIKTNING-") + 12];
+static char identifier[sizeof ("ESP8266-") + 12];
 
 // Our config file load/save and the web settings server.
 static grmcdorman::device::ConfigFile config;
 static grmcdorman::WebSettings webServer;
 
 // Device declarations. Order is not important.
-static ::grmcdorman::device::InfoDisplay info_display;
-static ::grmcdorman::device::SystemDetailsDisplay system_details_display;
-static ::grmcdorman::device::WifiDisplay wifi_display;
 static ::grmcdorman::device::WifiSetup wifi_setup;
-static ::grmcdorman::device::Sht31Sensor sht31_sensor;
-static ::grmcdorman::device::VindriktningAirQuality vindriktning_air_quality;
+static ::grmcdorman::device::ThermistorSensor thermistor_sensor(THERMISTOR_THERMAL_INDEX, 273.15 + THERMISTOR_REFERENCE_TEMPERATURE_CELCIUS);
 
 // This uses the default WiFiClient for communications.
 static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), FPSTR(model), FPSTR(software_version));
@@ -80,17 +68,12 @@ static ::grmcdorman::device::MqttPublisher mqtt_publisher(FPSTR(manufacturer), F
 // Device list. Order _is_ important; this is the order they're presented on the web page.
 static std::vector<grmcdorman::device::Device *> devices
 {
-    &info_display,
-    &system_details_display,
-    &wifi_display,
+    &thermistor_sensor,
     &wifi_setup,
-    &sht31_sensor,
-    &vindriktning_air_quality,
     &mqtt_publisher
 };
 
 // State.
-static bool set_save_credentials = false;       //!< Set to true when credentials for save/restart etc. have been configured.
 static bool factory_reset_next_loop = false;    //!< Set to true when a factory reset has been requested.
 static bool restart_next_loop = false;          //!< Set to true when a simple reset has been requested.
 static uint32_t restart_reset_when = 0;         //!< The time the factory reset/reset was requested.
@@ -115,17 +98,9 @@ void setup() {
 
     // Set some defaults.
 
-    // Device index # 0 is InfoDisplay. It has no relevant settings.
-    // Device index # 1 is System Details Display. It has no relevant settings.
-    // Device index # 2 is WiFi display. It has no relevant settings.
-    // Device index # 3 is the WiFi setup. A default AP and password could be set:
-    devices[3]->set("ssid", "my access point");
+    wifi_setup.set("ssid", "my access point");
     // Note that this will *not* be shown in the web page UI.
-    devices[3]->set("password", "my password");
-
-    // Device index # 4 is the SHT31-D. Set the default sda to D2, scl to D3.
-    devices[4]->set("sda", "D2");
-    devices[4]->set("scl", "D3");
+    wifi_setup.set("password", "my password");
 
     for (auto &device: devices)
     {
@@ -139,9 +114,7 @@ void setup() {
 
     // Print some device settings.
     Serial.print("WiFi SSID is ");
-    Serial.println(devices[3]->get("ssid"));
-    Serial.print("SHT31-D SDA is on pin ");
-    Serial.println(devices[4]->get("sda"));
+    Serial.println(wifi_setup.get("ssid"));
 
     for (auto &device : devices)
     {
@@ -150,13 +123,6 @@ void setup() {
         webServer.add_setting_set(device->name(), device->identifier(), device->get_settings());
     }
 
-    if (WiFi.isConnected())
-    {
-        // SoftAP capture portal clients are typically not happy about authentication.
-        webServer.set_credentials("admin", identifier);
-        set_save_credentials = true;
-        setupOTA();
-    }
 
     webServer.setup(on_save, on_restart, on_factory_reset);
 
@@ -164,56 +130,8 @@ void setup() {
     Serial.println(WiFi.localIP().toString());
 }
 
-void setupOTA() {
-    ArduinoOTA.onStart([]() { Serial.println("Start"); });
-    ArduinoOTA.onEnd([]() { Serial.println("\nEnd"); });
-    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-        Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-    });
-    ArduinoOTA.onError([](ota_error_t error) {
-        Serial.printf("Error[%u]: ", error);
-        if (error == OTA_AUTH_ERROR) {
-            Serial.println("Auth Failed");
-        } else if (error == OTA_BEGIN_ERROR) {
-            Serial.println("Begin Failed");
-        } else if (error == OTA_CONNECT_ERROR) {
-            Serial.println("Connect Failed");
-        } else if (error == OTA_RECEIVE_ERROR) {
-            Serial.println("Receive Failed");
-        } else if (error == OTA_END_ERROR) {
-            Serial.println("End Failed");
-        }
-    });
-
-    // This needs a regular string.
-    ArduinoOTA.setHostname(String(WiFi.getHostname()).c_str());
-
-    // This could also be a setting
-    ArduinoOTA.setPassword(identifier);
-    ArduinoOTA.begin();
-}
-
 void loop()
 {
-    if (WiFi.isConnected())
-    {
-        if (!set_save_credentials)
-        {
-            // Connected to WiFi, but credentials for save/reset etc. were not set
-            webServer.set_credentials("admin", identifier);
-            set_save_credentials = true;
-        }
-    }
-    else if (WiFi.softAPgetStationNum() != 0)
-    {
-        if (set_save_credentials)
-        {
-            // In Soft AP mode with at least one client connected, and a password was set.
-            webServer.set_credentials(String(), String());
-        }
-    }
-
-    ArduinoOTA.handle();
     webServer.loop();
 
     for (auto &device : devices)

--- a/library.json
+++ b/library.json
@@ -42,6 +42,10 @@
     {
         "name": "external-repo",
         "version": "https://github.com/grmcdorman/esp8266_web_settings.git"
+    },
+    {
+        "name": "external-repo",
+        "version": "https://github.com/bertmelis/DHT"
     }
   ]
 }

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A sensor and device framework built on esp8266_web_settings with MQTT s
 paragraph=Provides generic compile-time multiple device support
 category=Other
 url=https://github.com/grmcdorman/esp8266_device_framework
-depends=ArduinoJson, ESPAsyncWebServer, PubSubClient, SHT31, esp8266_web_settings
+depends=ArduinoJson, ESPAsyncWebServer, PubSubClient, SHT31, bertmelis_DHT, esp8266_web_settings

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,10 +14,13 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 debug_port = COM3
+monitor_filters = esp8266_exception_decoder
 lib_deps =
 	bblanchon/ArduinoJson @ ^6.18.3
 	knolleary/PubSubClient @ ^2.8
 	robtillaart/SHT31
 	https://github.com/grmcdorman/esp8266_web_settings.git
-	# Uncomment this line if you want to use the smaller ESP Home Async Web Server.
-	#esphome/ESPAsyncWebServer-esphome@^2.1.0
+	esphome/ESPAsyncWebServer-esphome@^2.1.0
+	https://github.com/bertmelis/DHT.git#1.0.1
+	# To compile the LCD examples.
+#	marcoschwartz/LiquidCrystal_I2C@^1.1.4

--- a/src/AbstractAnalog.cpp
+++ b/src/AbstractAnalog.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "grmcdorman/device/AbstractAnalog.h"
+#include "grmcdorman/Setting.h"
+
+namespace grmcdorman::device
+{
+
+    AbstractAnalog::AbstractAnalog(const __FlashStringHelper *device_name, const __FlashStringHelper *device_identifier,
+        float defaultScale, float defaultOffset, bool invert):
+        Device(device_name, device_identifier),
+        scale(F("Scaling"), F("scale")),
+        offset(F("Offset"), F("offset")),
+        invertReading(F("Invert reading before transform"), F("invert_reading")),
+        readInterval(F("Polling interval (seconds)"), F("poll_interval"))
+    {
+        // Superclass will initialize.
+        scale.set(defaultScale);
+        offset.set(defaultOffset);
+        invertReading.set(invert);
+        readInterval.set(statusReadInterval / 1000);
+    }
+
+    void AbstractAnalog::setup()
+    {
+        if (!is_enabled())
+        {
+            return;
+        }
+
+        set_timer();
+    }
+
+    void AbstractAnalog::loop()
+    {
+        if (!is_enabled())
+        {
+            return;
+        }
+
+        if (current_polling_seconds != readInterval.get() || !ticker.active())
+        {
+            set_timer();
+        }
+    }
+
+    bool AbstractAnalog::publish(DynamicJsonDocument &json) const
+    {
+        if (!sensor_reading.has_accumulation() || !is_enabled())
+        {
+            return false;
+        }
+
+        json[identifier()] = as_json();
+
+        return true;
+    }
+
+    DynamicJsonDocument AbstractAnalog::as_json() const
+    {
+        DynamicJsonDocument json(512);
+        static const char enabled_string[] PROGMEM = "enabled";
+        json[FPSTR(enabled_string)] = is_enabled();
+        json[identifier()] = sensor_reading.as_json();
+
+        return json;
+    }
+
+    void AbstractAnalog::set_timer()
+    {
+        current_polling_seconds = readInterval.get();
+        ticker.attach(current_polling_seconds, [this]
+        {
+            if (is_enabled())
+            {
+                last_read_millis = millis();
+                last_raw_value = analogRead(A0);
+                if (invertReading.get())
+                {
+                    sensor_reading.new_reading(scale.get() / transform_raw_reading(last_raw_value) + offset.get());
+                }
+                else
+                {
+                    sensor_reading.new_reading(scale.get() * transform_raw_reading(last_raw_value) + offset.get());
+                }
+                clear_is_published();
+            }
+
+        });
+    }
+}

--- a/src/BasicAnalog.cpp
+++ b/src/BasicAnalog.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "grmcdorman/device/BasicAnalog.h"
+#include "grmcdorman/Setting.h"
+
+namespace grmcdorman::device
+{
+    namespace {
+        // Defaults.
+        const char basic_analog_name[] PROGMEM = "Basic Analog Reading";
+        const char basic_analog_identifier[] PROGMEM = "basic_analog";
+
+        class BasicAnalog_Definition: public Device::Definition
+        {
+            public:
+                BasicAnalog_Definition(const __FlashStringHelper *units): units(units)
+                {
+                }
+
+                virtual const __FlashStringHelper *get_name_suffix() const override
+                {
+                    return F(" Analog Reading");
+                }
+                virtual const __FlashStringHelper *get_value_template() const override
+                {
+                    return F("{{value_json.basic_analog.average}}");
+                }
+                virtual const __FlashStringHelper *get_unique_id_suffix() const override
+                {
+                    return F("_basic_analog");
+                }
+                virtual const __FlashStringHelper *get_unit_of_measurement() const override
+                {
+                    return units;
+                }
+                virtual const __FlashStringHelper *get_json_attributes_template() const override
+                {
+                    return F("{\"last\": \"{{value_json.basic_analog.last}}\", \"age\": \"{{value_json.basic_analog.sample_age_ms}}\"}");
+                }
+                virtual const __FlashStringHelper *get_icon() const override
+                {
+                    return F("mdi:alpha-s-circle");
+                }
+
+            private:
+                const __FlashStringHelper *units;
+        };
+    }
+
+    BasicAnalog::BasicAnalog(const __FlashStringHelper *units, bool allowUserAdjust, float defaultScale, float defaultOffset, bool invert):
+        AbstractAnalog(FPSTR(basic_analog_name), FPSTR(basic_analog_identifier), defaultScale, defaultOffset, invert),
+        title(F("<h2>Analog Data Line Reading (A0 input)</h2>")),
+        device_status(F("Sensor status<script>periodicUpdateList.push(\"basic_analog&setting=device_status\");</script>"), F("device_status"))
+    {
+        static const BasicAnalog_Definition definition(units);
+
+        if (allowUserAdjust)
+        {
+            initialize({&definition}, {&title, &scale, &offset, &invertReading,
+                &readInterval, &device_status, &enabled});
+        }
+        else
+        {
+            initialize({&definition}, {&title,
+                &readInterval, &device_status, &enabled});
+        }
+
+        set_enabled(false);
+
+        device_status.set_request_callback([this] (const InfoSettingHtml &)
+        {
+            if (!is_enabled())
+            {
+                device_status.set(F("Sensor is disabled"));
+                return;
+            }
+            device_status.set(get_status());
+        });
+    }
+
+
+    String BasicAnalog::get_status() const
+    {
+        if (!is_enabled())
+        {
+            return String();
+        }
+
+        String message;
+        message.reserve(150);
+        char float_str[64];
+        dtostrf(get_last_reading(), 1, 1, float_str);
+        message = float_str;
+        message += ';';
+        message += ' ';
+        auto since = millis() - last_read_millis;
+        message += since / 1000;
+        message += F(" seconds since last reading.");
+
+        return message;
+    }
+}

--- a/src/ConfigFile.cpp
+++ b/src/ConfigFile.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include <ArduinoJson.h>
 #include <LittleFS.h>
 

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "grmcdorman/device/Device.h"
 
 #include <algorithm>

--- a/src/ThermistorSensor.cpp
+++ b/src/ThermistorSensor.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "grmcdorman/device/ThermistorSensor.h"
+#include "grmcdorman/Setting.h"
+
+namespace grmcdorman::device
+{
+    namespace {
+        // Defaults.
+        const char thermistor_name[] PROGMEM = "Temperature";
+        const char thermistor_identifier[] PROGMEM = "thermistor";
+
+        class Thermistor_Definition: public Device::Definition
+        {
+            public:
+                virtual const __FlashStringHelper *get_name_suffix() const override
+                {
+                    return F(" Temperature");
+                }
+                virtual const __FlashStringHelper *get_value_template() const override
+                {
+                    return F("{{value_json.thermistor.average}}");
+                }
+                virtual const __FlashStringHelper *get_unique_id_suffix() const override
+                {
+                    return F("_thermistor");
+                }
+                virtual const __FlashStringHelper *get_unit_of_measurement() const override
+                {
+                    return F("°C");
+                }
+                virtual const __FlashStringHelper *get_json_attributes_template() const override
+                {
+                    return F("{\"last\": \"{{value_json.thermistor.last}}\", \"age\": \"{{value_json.thermistor.sample_age_ms}}\"}");
+                }
+                virtual const __FlashStringHelper *get_icon() const override
+                {
+                    return F("mdi:thermometer");
+                }
+        };
+    }
+
+    ThermistorSensor::ThermistorSensor(float thermalIndex, float t1Kelvin):
+        AbstractAnalog(FPSTR(thermistor_name), FPSTR(thermistor_identifier)),
+        inverse_thermal_index(1.0 / thermalIndex),
+        inverse_t1(1.0 / t1Kelvin),
+        title(F("<h2>Temperature (ThermistorSensor)</h2>")),
+        device_status(F("Sensor status<script>periodicUpdateList.push(\"thermistor&setting=device_status\");</script>"), F("device_status"))
+    {
+        static const Thermistor_Definition definition;
+
+        initialize({&definition}, {&title, &scale, &offset,
+            &readInterval, &device_status, &enabled});
+
+        set_enabled(false);
+
+        device_status.set_request_callback([this] (const InfoSettingHtml &)
+        {
+            if (!is_enabled())
+            {
+                device_status.set(F("Sensor is disabled"));
+                return;
+            }
+            device_status.set(get_status());
+        });
+    }
+
+    DynamicJsonDocument ThermistorSensor::as_json() const
+    {
+        static const char temperature_string[] PROGMEM = "temperature";
+        static const char last_temperature_string[] PROGMEM = "last_temperature";
+        static const char enabled_string[] PROGMEM = "enabled";
+        DynamicJsonDocument json(512);
+
+        json[FPSTR(enabled_string)] = is_enabled();
+        json[FPSTR(temperature_string)] = get_current_average();
+        json[FPSTR(last_temperature_string)] = get_last_reading();
+
+        return json;
+    }
+
+    String ThermistorSensor::get_status() const
+    {
+        if (!is_enabled())
+        {
+            return String();
+        }
+
+        String message;
+        message.reserve(150);
+        char float_str[64];
+        dtostrf(get_last_reading(), 1, 1, float_str);
+        message = float_str;
+        message += F("°C; ");
+        auto since = millis() - last_read_millis;
+        message += since / 1000;
+        message += F(" seconds since last reading.");
+
+        return message;
+    }
+
+    float ThermistorSensor::transform_raw_reading(int reading)
+    {
+        // Equations are from https://www.jameco.com/Jameco/workshop/TechTip/temperature-measurement-ntc-thermistors.html
+        // Due to the requirements that:
+        // a) the maximum ADC and the Vref supplied to the thermistor are the same;
+        // b) the series resistor is sufficiently close to the thermistor at the temperatures being measured
+        // the simplified equation can be used:
+        //   1/T0 + 1/B * ln( ( adcMax / adcVal ) – 1 )
+        float tempK_inverse = inverse_t1 + inverse_thermal_index * log(1023.0 / reading - 1);
+        // Convert 1/K to degrees C.
+        float tempC = 1 / tempK_inverse - 273.15;
+
+        return tempC;
+    }
+}

--- a/src/WebServerRestAPI.cpp
+++ b/src/WebServerRestAPI.cpp
@@ -33,12 +33,12 @@ namespace grmcdorman::device
     {
     }
 
-    void WebServerRestApi::setup(AsyncWebServer &server)
+    void WebServerRestApi::setup(AsyncWebServer &server, const std::vector<Device *> &devices)
     {
 
         // The filters are required because the AsyncWebServer accepts any path
         // that *starts* with the URI.
-        for (const auto &device: *devices)
+        for (const auto &device: devices)
         {
             String path(F("/rest/device/"));
             path += device->identifier();
@@ -53,11 +53,11 @@ namespace grmcdorman::device
             );
         }
 
-        server.on("/rest/devices/get", HTTP_GET, [this]  (AsyncWebServerRequest *request)
+        server.on("/rest/devices/get", HTTP_GET, [&devices]  (AsyncWebServerRequest *request)
         {
             auto response = new AsyncJsonResponse(true);
             auto & root = response->getRoot();
-            for (const auto &device: *devices)
+            for (const auto &device: devices)
             {
                 root.add(device->identifier());
             }

--- a/src/WebServerRestAPI.cpp
+++ b/src/WebServerRestAPI.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ESP8266WiFi.h>
+#include <ArduinoJson.h>
+#include <AsyncJson.h>
+#include <ESPAsyncWebServer.h>
+
+#include "grmcdorman/device/WebServerRestAPI.h"
+
+namespace grmcdorman::device
+{
+    WebServerRestApi::WebServerRestApi()
+    {
+    }
+
+    void WebServerRestApi::setup(AsyncWebServer &server)
+    {
+
+        // The filters are required because the AsyncWebServer accepts any path
+        // that *starts* with the URI.
+        for (const auto &device: *devices)
+        {
+            String path(F("/rest/device/"));
+            path += device->identifier();
+            path += F("/get");
+            server.on(path.c_str(), HTTP_GET, [this, device] (AsyncWebServerRequest *request)
+            {
+                handle_on_device_get(request, device);
+            }).setFilter([path] (AsyncWebServerRequest *request)
+                {
+                    return request->url() == path;
+                }
+            );
+        }
+
+        server.on("/rest/devices/get", HTTP_GET, [this]  (AsyncWebServerRequest *request)
+        {
+            auto response = new AsyncJsonResponse(true);
+            auto & root = response->getRoot();
+            for (const auto &device: *devices)
+            {
+                root.add(device->identifier());
+            }
+            response->setLength();
+            response->addHeader("Cache-Control", "no-cache");
+            request->send(response);
+        }).setFilter([] (AsyncWebServerRequest *request)
+            {
+                return request->url() == F("/rest/devices/get");
+            }
+        );
+    }
+
+    void WebServerRestApi::handle_on_device_get(AsyncWebServerRequest *request, const Device *device)
+    {
+        auto response = new AsyncJsonResponse(false);
+        auto & root = response->getRoot();
+        root[device->identifier()] =  device->as_json();
+        response->setLength();
+        response->addHeader("Cache-Control", "no-cache");
+        request->send(response);
+    }
+}

--- a/src/WifiDisplay.cpp
+++ b/src/WifiDisplay.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 #include <ESP8266WiFi.h>
 #include "grmcdorman/device/WifiDisplay.h"
@@ -77,5 +98,26 @@ namespace grmcdorman::device
             station_autoconnect.set(bool_to_yesno(WiFi.getAutoConnect()));
         });
 
+    }
+    DynamicJsonDocument WifiDisplay::as_json() const
+    {
+        DynamicJsonDocument json(128 * get_settings().size());
+
+        static const char enabled_string[] PROGMEM = "enabled";
+
+        json[FPSTR(enabled_string)] = is_enabled();
+        for (const auto &setting: get_settings())
+        {
+            if (setting->send_to_ui() && setting != &title && setting != &enabled && setting != &station_connected && setting != &station_autoconnect)
+            {
+                // This will invoke the request callback, which will update the contents as a side effect.
+                json[setting->name()] = setting->as_string();
+            }
+        }
+        // These two are booleans.
+        json[station_connected.name()] = WiFi.isConnected();
+        json[station_autoconnect.name()] = WiFi.getAutoConnect();
+
+        return json;
     }
 }

--- a/src/WifiSetup.cpp
+++ b/src/WifiSetup.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include <ESP8266WiFi.h>
 
 #include "grmcdorman/device/WifiSetup.h"
@@ -5,8 +27,10 @@
 namespace grmcdorman::device
 {
     namespace {
-        auto SSID_STRING_LOWER = FPSTR("ssid");
-        auto WIFI_STRING_LOWER = FPSTR("wifi");
+        const char ssid_string_lower[] PROGMEM = "ssid";
+        const char wifi_string_lower[] PROGMEM = "wifi";
+        auto SSID_STRING_LOWER = FPSTR(ssid_string_lower);
+        auto WIFI_STRING_LOWER = FPSTR(wifi_string_lower);
         const char wifi_name[] PROGMEM = "WiFi";
         const char wifi_identifier[] PROGMEM = "wifi_setup";
         class WifiSetupDevice_Definition: public Device::Definition
@@ -199,21 +223,29 @@ namespace grmcdorman::device
         }
     }
 
-    bool WifiSetup::publish(DynamicJsonDocument &json)
+    bool WifiSetup::publish(DynamicJsonDocument &json) const
     {
         if (!publish_rssi.get())
         {
             return false;
         }
 
-        DynamicJsonDocument wifiJson(512);
-
-        wifiJson[SSID_STRING_LOWER] = WiFi.SSID();
-        wifiJson[F("ip")] = WiFi.localIP().toString();
-        wifiJson[F("rssi")] = WiFi.RSSI();
-
-        json[WIFI_STRING_LOWER] = wifiJson.as<JsonObject>();
+        // This device is unique in not using the device identifier here.
+        json[WIFI_STRING_LOWER] = as_json();
 
         return true;
+    }
+
+    DynamicJsonDocument WifiSetup::as_json() const
+    {
+        static const char enabled_string[] PROGMEM = "enabled";
+        DynamicJsonDocument json(512);
+
+        json[FPSTR(enabled_string)] = is_enabled();
+        json[SSID_STRING_LOWER] = WiFi.SSID();
+        json[F("ip")] = WiFi.localIP().toString();
+        json[F("rssi")] = WiFi.RSSI();
+
+        return json;
     }
 }

--- a/src/esp8266_device_framework.h
+++ b/src/esp8266_device_framework.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
     /**

--- a/src/grmcdorman/device/AbstractAnalog.h
+++ b/src/grmcdorman/device/AbstractAnalog.h
@@ -110,16 +110,16 @@ namespace grmcdorman::device
             virtual float transform_raw_reading(int reading) = 0;
             FloatSetting scale;                 //!< Offset.
             FloatSetting offset;                //!< Scaling.
-            ToggleSetting invertReading;        //<! Whether to invert the reading.
+            ToggleSetting invertReading;        //!< Whether to invert the reading.
             UnsignedIntegerSetting readInterval;//!< How often to request a reading.
             uint32_t last_read_millis = 0;      //!< Timestamp of last read.
             //!< Default read interval. Chosen such that there should be 5 readings per 30 seconds.
             constexpr static uint32_t statusReadInterval = (30 / 5) * 1000;
             Accumulator<float, 5> sensor_reading;  //!< Reading.
         private:
-            void set_timer();                   //<! Set up ticker timer.
-            Ticker ticker;                      //<! Ticker to handle readings.
-            uint32_t current_polling_seconds = 0;//<! Current polling interval.
+            void set_timer();                   //!< Set up ticker timer.
+            Ticker ticker;                      //!< Ticker to handle readings.
+            uint32_t current_polling_seconds = 0;//!< Current polling interval.
             float last_raw_value = 0;           //!< Last raw value.
     };
 }

--- a/src/grmcdorman/device/AbstractAnalog.h
+++ b/src/grmcdorman/device/AbstractAnalog.h
@@ -113,8 +113,7 @@ namespace grmcdorman::device
             ToggleSetting invertReading;        //!< Whether to invert the reading.
             UnsignedIntegerSetting readInterval;//!< How often to request a reading.
             uint32_t last_read_millis = 0;      //!< Timestamp of last read.
-            //!< Default read interval. Chosen such that there should be 5 readings per 30 seconds.
-            constexpr static uint32_t statusReadInterval = (30 / 5) * 1000;
+            constexpr static uint32_t statusReadInterval = (30 / 5) * 1000;//!< Default read interval. Chosen such that there should be 5 readings per 30 seconds.
             Accumulator<float, 5> sensor_reading;  //!< Reading.
         private:
             void set_timer();                   //!< Set up ticker timer.

--- a/src/grmcdorman/device/AbstractAnalog.h
+++ b/src/grmcdorman/device/AbstractAnalog.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+#include <Ticker.h>
+
+#include "grmcdorman/device/Device.h"
+#include "grmcdorman/device/Accumulator.h"
+
+namespace grmcdorman::device
+{
+    /**
+     * @brief Abstract analog device.
+     *
+     * This device reads A0; the value can be transformed by
+     * a scale and an offset before reporting. The value can also
+     * be inverted (i.e. 1/value).
+     *
+     * This device doesn't provide full services; it's intended to
+     * be derived in other classes that can transform the raw
+     * value into meaningful output.
+     *
+     */
+    class AbstractAnalog: public Device
+    {
+        public:
+            /**
+             * @brief Construct a new Basic Analog object.
+             *
+             * @param device_name       Device name.
+             * @param device_identifier Device identifier.
+             * @param defaultScale      Default scaling value.
+             * @param defaultOffset     Default offset value.
+             * @param invert            If true, invert the reading before applying scale and offset.
+             */
+            explicit AbstractAnalog(const __FlashStringHelper *device_name, const __FlashStringHelper *device_identifier,
+                float defaultScale = 1.0f, float defaultOffset = 0.0f, bool invert = false);
+
+            void setup() override;
+            void loop() override;
+            bool publish(DynamicJsonDocument &json) const override;
+
+            /**
+             * @brief Last computed reading.
+             *
+             * @return float
+             */
+            float get_last_reading() const
+            {
+                return sensor_reading.get_last_reading();
+            }
+
+            /**
+             * @brief Last raw value (no scale or offset applied).
+             *
+             * @return float
+             */
+            float raw_value() const
+            {
+                return last_raw_value;
+            }
+
+            /**
+             * @brief Get the last average reading.
+             *
+             * Only valid after a call to `reset_accumulation`
+             * that returns `true`.
+             *
+             * @return float
+             */
+            float get_current_average() const
+            {
+                return sensor_reading.get_current_average();
+            }
+
+            DynamicJsonDocument as_json() const override;
+        protected:
+            /**
+             * @brief Transform the raw reading into the reported value.
+             *
+             * This can, for example, transform the raw A0 value into
+             * volts, or transform a thermistor value in to degrees Celcius.
+             *
+             * Do not apply the scaling, offset, and invert values in this method;
+             * they will be automatically applied on the returned value.
+             * @param reading   The raw reading.
+             * @return float    The transformed reading.
+             */
+            virtual float transform_raw_reading(int reading) = 0;
+            FloatSetting scale;                 //!< Offset.
+            FloatSetting offset;                //!< Scaling.
+            ToggleSetting invertReading;        //<! Whether to invert the reading.
+            UnsignedIntegerSetting readInterval;//!< How often to request a reading.
+            uint32_t last_read_millis = 0;      //!< Timestamp of last read.
+            //!< Default read interval. Chosen such that there should be 5 readings per 30 seconds.
+            constexpr static uint32_t statusReadInterval = (30 / 5) * 1000;
+            Accumulator<float, 5> sensor_reading;  //!< Reading.
+        private:
+            void set_timer();                   //<! Set up ticker timer.
+            Ticker ticker;                      //<! Ticker to handle readings.
+            uint32_t current_polling_seconds = 0;//<! Current polling interval.
+            float last_raw_value = 0;           //!< Last raw value.
+    };
+}

--- a/src/grmcdorman/device/AbstractTemperaturePressureSensor.h
+++ b/src/grmcdorman/device/AbstractTemperaturePressureSensor.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "grmcdorman/device/Device.h"
+#include "grmcdorman/device/Accumulator.h"
+
+namespace grmcdorman::device
+{
+    /**
+     * @brief This is an abstract base class for temperature/pressor sensors.
+     *
+     * This provides support for devices that publish humidity and temperature.
+     * It provides the common functionality to publish averages of these two
+     * readings.
+     */
+    class AbstractTemperaturePressureSensor: public Device
+    {
+        public:
+            /**
+             * @brief Construct a new Abstract Temperature Pressure Sensor object.
+             *
+             * @param device_name       Device name.
+             * @param device_identifier Device identifier.
+             */
+            AbstractTemperaturePressureSensor(const __FlashStringHelper *device_name, const __FlashStringHelper *device_identifier):
+                Device(device_name, device_identifier)
+            {
+            }
+            DynamicJsonDocument as_json() const override
+            {
+                static const char temperature_string[] PROGMEM = "temperature";
+                static const char humidity_string[] PROGMEM = "humidity";
+                static const char enabled_string[] PROGMEM = "enabled";
+                DynamicJsonDocument json(1024);
+
+                json[FPSTR(enabled_string)] = is_enabled();
+                json[FPSTR(temperature_string)] = std::move(temperature.as_json());
+                json[FPSTR(humidity_string)] = std::move(humidity.as_json());
+
+                return json;
+            }
+
+            bool publish(DynamicJsonDocument &json) const
+            {
+                if (!temperature.has_accumulation() || !is_enabled())
+                {
+                    return false;
+                }
+
+                json[identifier()] = as_json();
+
+                return true;
+            }
+
+            /**
+             * @brief Get the last temperature reading.
+             *
+             * @return Last temperature reading; INVALID_READING if never read.
+             */
+            float get_temperature() const
+            {
+                return temperature.get_last_reading();
+            }
+
+            /**
+             * @brief Get the last humidity reading.
+             *
+             * @return Last humidity reading; INVALID_READING if never read.
+             */
+            float get_humidity() const
+            {
+                return humidity.get_last_reading();
+            }
+
+            static constexpr int INVALID_READING = -273;        //!< The invalid reading value.
+        protected:
+            Accumulator<float, 5, INVALID_READING> temperature;    //!< The temperature accumulator.
+            Accumulator<float, 5, INVALID_READING> humidity;       //!< The humidity accumulator.
+    };
+}

--- a/src/grmcdorman/device/Accumulator.h
+++ b/src/grmcdorman/device/Accumulator.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <WString.h>
+#include <ArduinoJson.h>
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+namespace grmcdorman::device
+{
+
+        /**
+         * @brief A class to handle accumulating values.
+         *
+         * This provides tracking for a reading, giving both the
+         * most recent reading and the current running average.
+         *
+         * The number of readings required for a running average is configurable,
+         * and is not time-based. It defaults to 10 readings.
+         *
+         * The intent is that readings are accumulated until a
+         * reading is published, at which time `reset` is called
+         * to begin accumulating anew.
+         *
+         * @tparam T        The type being accumulated; must be an arithmetic type, e.g. int32_t or float.
+         * @tparam unset    The unset value. Defaults to `T()`, which is likely to be zero.
+         * @tparam zero     The zero value; defaults to 0.
+         */
+        template<typename T, uint8_t N, int unset = 0, int zero = 0>
+        class Accumulator
+        {
+        public:
+            static constexpr T unset_value = unset;     //!< The unset value.
+            static constexpr T zero_value = zero;       //!< The zero value.
+            static constexpr uint8_t average_points = N;//!< The number of readings for the rolling average.
+            typedef T value_type;                       //!< The value type.
+
+            /**
+             * @brief Get the current value.
+             *
+             * This is the last value supplied to `new_reading`. If
+             * a value has never been read, the returned value will be
+             * `unset_value`.
+             *
+             * @return Last reading
+             */
+            T get_last_reading() const
+            {
+                return last_reading;
+            }
+            /**
+             * @brief Get the current rolling average.
+             *
+             * This is the rolling average for the last N readings;
+             * if fewer than N have been accumulated, it is the average
+             * of those.
+             *
+             * @return Current average.
+             */
+            float get_current_average() const
+            {
+                uint8_t count = std::min(data_read_first, average_points);
+                return count == 0 ? unset_value : std::accumulate(&last_reading_set[0], &last_reading_set[count], zero_value) / static_cast<float>(count);
+            }
+            /**
+             * @brief Record a new reading.
+             *
+             * The `last_reading` is set to this value,
+             * and the reading is accumulated in the rolling average set.
+             *
+             * @param new_value New reading.
+             */
+            void new_reading(T new_value)
+            {
+                last_reading = new_value;
+                last_reading_set[current_index] = new_value;
+                current_index = (current_index + 1) % N;
+                if (data_read_first < N)
+                {
+                    ++data_read_first;
+                }
+                last_sample_time = millis();
+            }
+            /**
+             * @brief Return a value indicate whether data has been accumulated.
+             *
+             * @return true     At least one reading has been accumulated.
+             * @return false    No readings have been accumulated.
+             */
+            bool has_accumulation() const
+            {
+                return data_read_first > 0;
+            }
+
+            /**
+             * @brief Get the number of samples used for the average.
+             *
+             * At first this will be less than the configured maximum until
+             * sufficient samples have been collected.
+             * @return Sample count.
+             */
+            uint8_t get_sample_count() const
+            {
+                return data_read_first;
+            }
+
+            /**
+             * @brief Get the last sample age, in milliseconds.
+             *
+             * @return Last sample age.
+             */
+            uint32_t get_last_sample_age() const
+            {
+                return millis() - last_sample_time;
+            }
+
+            /**
+             * @brief Get the values in standard JSON.
+             *
+             * @return DynamicJsonDocument containing values.
+             */
+            DynamicJsonDocument as_json() const
+            {
+                static const char average_string[] PROGMEM = "average";
+                static const char last_string[] PROGMEM = "last";
+                static const char sample_count_string[] PROGMEM = "sample_count";
+                static const char sample_age_string[] PROGMEM = "sample_age_ms";
+
+                DynamicJsonDocument json(128);
+                json[FPSTR(average_string)] = get_current_average();
+                json[FPSTR(last_string)] = get_last_reading();
+                json[FPSTR(sample_count_string)] = get_sample_count();
+                json[FPSTR(sample_age_string)] = get_last_sample_age();
+                return json;
+            }
+
+        private:
+            T last_reading = unset_value;           //!< The last reading.
+            T last_reading_set[N];                  //!< The last <N> readings.
+            uint32_t current_index = 0;             //!< The number of readings since the last reset.
+            uint8_t data_read_first = 0;            //!< The number of points in the first set; no more than N.
+            uint32_t last_sample_time = 0;          //!< The last sample time.
+        };
+}

--- a/src/grmcdorman/device/BasicAnalog.h
+++ b/src/grmcdorman/device/BasicAnalog.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+#include "grmcdorman/device/AbstractAnalog.h"
+
+namespace grmcdorman::device
+{
+    /**
+     * @brief A basic analog device.
+     *
+     * This device reads A0; the value can be transformed by
+     * a scale and an offset before reporting. The value can also
+     * be inverted (i.e. 1/value).
+     *
+     * This can be used for devices like potentiometers or photoresistors; anything
+     * where the input is linear. Note that thermistors do not have a linear response;
+     * there is a seperate class - `ThermistorSensor` for handling them.
+     *
+     * Appropriate scaling and offsets can be applied, possibly with inversion, to
+     * convert the raw reading to a range of interest.
+     *
+     * The raw reading has a range of 0 to 1024 on ESP8266. The maximum value
+     * may correspond to 1V, or 3.3V on the A0 (ADC) pin. You can determine this maximum
+     * by using a potentiometer connected across the +3.3V and GND, with the middle connection
+     * to the A0. If the reading reaches the maximum (1023 or 1024) when the potentiometer
+     * is only about 1/3 turned and remains at that value for the rest of the range, then your ADC has a maximum
+     * value of 1.0V.
+     *
+     * @note The units passed in the constructor are only obeyed for the first BasicAnalog device;
+     * all other BasicAnalog devices get the same units. This is probably not a problem, as the
+     * ESP8266 has only one ADC anyway.
+     *
+     * If the application requires fixed scaling, pass `false` as the second parameter to the
+     * constructor so that the scaling cannot be changed.
+     */
+    class BasicAnalog: public AbstractAnalog
+    {
+        public:
+            /**
+             * @brief Construct a new Basic Analog object.
+             *
+             * @param units             Units. Required for publishing to MQTT/Home Assistant.
+             * @param allowUserAdjust   If `true`, the user can adust scaling/offset/inversion in the UI, and the values are saved.
+             * @param defaultScale      Default scaling value.
+             * @param defaultOffset     Default offset value.
+             * @param invert            If true, invert the reading before applying scale and offset.
+             */
+            explicit BasicAnalog(const __FlashStringHelper *units, bool allowUserAdjust,
+                float defaultScale = 1.0f, float defaultOffset = 0.0f, bool invert = false);
+
+
+            /**
+             * @brief Get a status report.
+             *
+             * This is also used for the `device_status` info message, with the exception
+             * of various disabled states.
+             *
+             * @return String containing status report.
+             */
+            virtual String get_status() const;
+        protected:
+            virtual float transform_raw_reading(int reading) override
+            {
+                return reading;
+            };
+            NoteSetting title;                  //!< Device tab title.
+            InfoSettingHtml device_status;      //!< Last update
+    };
+}

--- a/src/grmcdorman/device/ConfigFile.h
+++ b/src/grmcdorman/device/ConfigFile.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include <optional>

--- a/src/grmcdorman/device/Device.h
+++ b/src/grmcdorman/device/Device.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include <WString.h>
@@ -243,7 +265,24 @@ namespace grmcdorman::device
              * @param[in,out] json JSON to receive the device values and attributes.
              * @return `true` if a value to be published was added; `false` otherwise.
              */
-            virtual bool publish(DynamicJsonDocument &json) = 0;
+            virtual bool publish(DynamicJsonDocument &json) const
+            {
+                return false;
+            }
+
+
+            /**
+             * @brief Get the values, as a JSON document.
+             *
+             * The structure is identical to the document created inside `publish`.
+             *
+             * @return DynamicJsonDocument
+             */
+            virtual DynamicJsonDocument as_json() const
+            {
+                // Return a null document.
+                return DynamicJsonDocument(8);
+            }
 
             /**
              * @brief The type containing a list of Definition objects.
@@ -343,6 +382,37 @@ namespace grmcdorman::device
                 return String();
             }
 
+            /**
+             * @brief Get whether the device readings have been published.
+             *
+             * The device is considered to be published if there are no readings
+             * since the last publish, or since system start.
+             * @return true     The device readings have been published.
+             * @return false    The device readings have not been published.
+             */
+            virtual bool get_is_published() const
+            {
+                return is_published;
+            }
+
+            /**
+             * @brief Set the device as having published readings.
+             *
+             * This should be called when the device is published.
+             */
+            void set_is_published()
+            {
+                is_published = true;
+            }
+
+            /**
+             * @brief Set the device as not having published readings.
+             *
+             */
+            void clear_is_published()
+            {
+                is_published = false;
+            }
             static const ExclusiveOptionSetting::names_list_t data_line_names;  //!< Names for each configurable data line; see `settingsMap`.
         protected:
             /**
@@ -397,6 +467,7 @@ namespace grmcdorman::device
         private:
             const __FlashStringHelper *device_name;                     //!< The device name, from the constructor.
             const __FlashStringHelper *device_identifier;               //!< The device identifier, from the constructor.
+            bool is_published = true;                                   //!< Whether this device has published since last reading. Initially `true` until first reading.
 
             static const __FlashStringHelper *firmware_name;            //!< The unique firmware prefix.
             static String system_identifier;                            //!< The unique system identifier.

--- a/src/grmcdorman/device/DhtSensor.h
+++ b/src/grmcdorman/device/DhtSensor.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <DHT.h>
+#include <Ticker.h>
+
+#include "grmcdorman/device/AbstractTemperaturePressureSensor.h"
+
+namespace grmcdorman::device
+{
+    /**
+     * @brief This class supports the DHT11 and DHT22 sensors as a device.
+     *
+     * The specific sensor is selected at run-time by the "dht_model" setting.
+     * The sensor provides humidity and temperature. Readings are published
+     * as the average of all readings made since the last publish.
+     *
+     * This uses Bert Melis' https://github.com/bertmelis/DHT, an interrupt-driven handler,
+     * to perform the readings.
+     *
+     * For four-pin DHT packages, a 5K or 10K pull-up resistor connected to VDD (typically +5V)
+     * is required on the signal pin (pin 2). Pin 1 is VDD, and pin 4 is GND. Pins are numbered
+     * from left to right when viewing the front (performated) side of the sensor.
+     *
+     * The minimum read interval for DHT11 is 1 second; for DHT22 is 2 seconds. The
+     * settings do not enforce this minimum.
+     */
+    class DhtSensor: public AbstractTemperaturePressureSensor
+    {
+        public:
+            DhtSensor();
+
+            void setup() override;
+            void loop() override;
+
+            /**
+             * @brief Get a status report.
+             *
+             * This is also used for the `device_status` info message, with the exception
+             * of various disabled states.
+             *
+             * When the DhtSensor is disabled or nonoperational,
+             * this returns an empty string.
+             *
+             * @return String containing status report.
+             */
+            virtual String get_status() const;
+        private:
+            //!< Default read interval. Chosen such that there should be 5 readings per 30 seconds.
+            constexpr static uint32_t statusReadInterval = (30 / 5) * 1000;
+
+            void set_timer();                           //!< Set the timer callback.
+            void reset_dht();                           //!< Reset DHT on the first read request following an error.
+
+            std::unique_ptr<DHT> dht;                   //!< Ether DHT11 or DHT22, depending on configuration.
+            Ticker ticker;                              //<! Ticker used to schedule readings.
+            int last_status = 0;                        //<! Last reported error status.
+            uint32_t last_read_millis = 0;              //<! Last read millis().
+            uint32_t current_polling_seconds = 0;       //<! Current polling interval.
+            bool requested = false;                     //!< Whether a reading was requested.
+            uint32_t request_previous_mills = 0;        //!< The time since the last read request.
+            NoteSetting title;                          //!< Device tab title.
+            ExclusiveOptionSetting dataPin;             //!< Data pin configuration.
+            ExclusiveOptionSetting dhtModel;            //!< Choice of DHT11 or DHT22.
+            FloatSetting temperatureOffset;             //!< Offset applied to temperature readings.
+            FloatSetting temperatureScale;              //!< Scaling applied to temperature readings.
+            FloatSetting humidityOffset;                //!< Offset applied to humidity readings.
+            FloatSetting humidityScale;                 //!< Scaling applied to humidity readings.
+            UnsignedIntegerSetting readInterval;        //!< How often to request a reading.
+            InfoSettingHtml device_status;              //!< Last update
+    };
+}

--- a/src/grmcdorman/device/DhtSensor.h
+++ b/src/grmcdorman/device/DhtSensor.h
@@ -76,10 +76,10 @@ namespace grmcdorman::device
             void reset_dht();                           //!< Reset DHT on the first read request following an error.
 
             std::unique_ptr<DHT> dht;                   //!< Ether DHT11 or DHT22, depending on configuration.
-            Ticker ticker;                              //<! Ticker used to schedule readings.
-            int last_status = 0;                        //<! Last reported error status.
-            uint32_t last_read_millis = 0;              //<! Last read millis().
-            uint32_t current_polling_seconds = 0;       //<! Current polling interval.
+            Ticker ticker;                              //!< Ticker used to schedule readings.
+            int last_status = 0;                        //!< Last reported error status.
+            uint32_t last_read_millis = 0;              //!< Last read millis().
+            uint32_t current_polling_seconds = 0;       //!< Current polling interval.
             bool requested = false;                     //!< Whether a reading was requested.
             uint32_t request_previous_mills = 0;        //!< The time since the last read request.
             NoteSetting title;                          //!< Device tab title.

--- a/src/grmcdorman/device/InfoDisplay.h
+++ b/src/grmcdorman/device/InfoDisplay.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 
@@ -38,17 +60,9 @@ namespace grmcdorman::device
             void loop() override
             {
             }
-            /**
-             * @brief Publish to MQTT.
-             *
-             * This class does not publish to MQTT.
-             * @param json  Not used.
-             * @return `false`  No data published.
-             */
-            bool publish(DynamicJsonDocument &json) override
-            {
-                return false;
-            }
+
+            DynamicJsonDocument as_json() const override;
+
             /**
              * @brief Add a list of devices that will report status.
              *

--- a/src/grmcdorman/device/MqttPublisher.h
+++ b/src/grmcdorman/device/MqttPublisher.h
@@ -160,8 +160,8 @@ namespace grmcdorman::device
              */
             void set_timer();
 
-            const __FlashStringHelper *publish_manufacturer;    //<! The manufacturer from the constructor.
-            const __FlashStringHelper *publish_model;           //<! The model from the constructor.
+            const __FlashStringHelper *publish_manufacturer;    //!< The manufacturer from the constructor.
+            const __FlashStringHelper *publish_model;           //!< The model from the constructor.
             const __FlashStringHelper *publish_software_version;//!< The sofware version from the constructor.
 
             const std::vector<Device *> *devices = nullptr; //!< The list of attached devices that will be published.
@@ -175,7 +175,7 @@ namespace grmcdorman::device
             bool tried_publish = false;                     //!< Set to true on the first publish attempt.
             bool last_publish_failed = false;               //!< Success/fail for last data publish.
             int last_state = -1;                            //!< Last known MQTT state.
-            uint32_t current_publish_seconds = 0;           //<! Current publish interval.
+            uint32_t current_publish_seconds = 0;           //!< Current publish interval.
 
             String topicAvailability;                       //!< The availability topic string. Used when connecting.
             String topicState;                              //!< The state topic string. Used when connecting.

--- a/src/grmcdorman/device/MqttPublisher.h
+++ b/src/grmcdorman/device/MqttPublisher.h
@@ -1,7 +1,30 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include <memory>
 #include <PubSubClient.h>
+#include <Ticker.h>
 
 #include "grmcdorman/device/Device.h"
 #include "grmcdorman/Setting.h"
@@ -16,10 +39,17 @@ namespace grmcdorman::device
      * SSL connections are not currently supported.
      *
      * It does not support subscriptions.
+     *
+     * If the connection is lost, an immediate attempt to connect is made on the next publish attempt.
+     *
+     * When a connection is attempted, the device will attempt `CONNECTION_TRIES` at an interval of `CONNECTION_RETRY_INTERVAL`. If this
+     * fails, it will not attempt a connection again until the configured reconnection interval elapses.
      */
     class MqttPublisher: public Device
     {
         public:
+            static constexpr uint16_t CONNECTION_TRIES = 5;             //!< Number of times to try establishing a connection.
+            static constexpr uint32_t CONNECTION_RETRY_INTERVAL = 5;    //!< Second between attempts to retry establishing a connection.
             /**
              * @brief Construct a new Mqtt Device object.
              *
@@ -28,7 +58,7 @@ namespace grmcdorman::device
              * supply your name as the manufacturer and the model as "Weather Station".
              *
              * The software version is not restricted to standard naming conventions; one simple solution
-             * is to use the predefined __DATE__ and __TIME__ macros. Do so would give a simple unique
+             * is to use the predefined __DATE__ and __TIME__ macros. Doing so would give a simple unique
              * string to every build.
              *
              * The communication client, if provided, should be an appropriate client to be used for
@@ -49,9 +79,11 @@ namespace grmcdorman::device
              *
              */
             void set_defaults() override;
+
             void setup() override;
             void loop() override;
-            bool publish(DynamicJsonDocument &json) override;
+
+            DynamicJsonDocument as_json() const override;
 
             /**
              * @brief Add a list of devices that will publish.
@@ -120,6 +152,14 @@ namespace grmcdorman::device
              */
             String get_error_state_message(int state) const;
 
+            /**
+             * @brief Set up the publish timer.
+             *
+             * This does not set the connect timer; that's done when it's noticed
+             * that the connection needs to be established.
+             */
+            void set_timer();
+
             const __FlashStringHelper *publish_manufacturer;    //<! The manufacturer from the constructor.
             const __FlashStringHelper *publish_model;           //<! The model from the constructor.
             const __FlashStringHelper *publish_software_version;//!< The sofware version from the constructor.
@@ -129,15 +169,20 @@ namespace grmcdorman::device
             std::unique_ptr<Client> default_client;         //!< The default communication client, when no client is provided. Created on demand if needed.
             Client                 *client;                 //!< The in-use client.
             std::unique_ptr<PubSubClient> mqttClient;       //!< The MQTT client.
+            uint16_t retry_count = 0;                       //!< When connecting, the number of retries.
             uint32_t previous_connection_attempt_ms = 0;    //!< The last connection attempt, system time.
             uint32_t previous_publish_ms = 0;               //!< The last publication, system time.
             bool tried_publish = false;                     //!< Set to true on the first publish attempt.
             bool last_publish_failed = false;               //!< Success/fail for last data publish.
             int last_state = -1;                            //!< Last known MQTT state.
+            uint32_t current_publish_seconds = 0;           //<! Current publish interval.
+
             String topicAvailability;                       //!< The availability topic string. Used when connecting.
             String topicState;                              //!< The state topic string. Used when connecting.
             String topicCommand;                            //!< The command - i.e. data publish - topic string.
 
+            Ticker connect_ticker;                          //!< Timer for checking connection & reconnecting.
+            Ticker publish_ticker;                          //!< Timer for publishing.
             NoteSetting notes;                              //!< A note setting with a description of the MQTT device.
             StringSetting server_address;                   //!< The user-configured server address.
             UnsignedIntegerSetting server_port;             //!< The user-configured server port.

--- a/src/grmcdorman/device/Sht31Sensor.h
+++ b/src/grmcdorman/device/Sht31Sensor.h
@@ -1,9 +1,31 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include <SHT31.h>
+#include <Ticker.h>
 
-#include "grmcdorman/device/Device.h"
-#include "grmcdorman/Setting.h"
+#include "grmcdorman/device/AbstractTemperaturePressureSensor.h"
 
 namespace grmcdorman::device
 {
@@ -13,14 +35,13 @@ namespace grmcdorman::device
      * The device provides humidity and temperature. Readings are published
      * as the average of all readings made since the last publish.
      */
-    class Sht31Sensor: public Device
+    class Sht31Sensor: public AbstractTemperaturePressureSensor
     {
         public:
             Sht31Sensor();
 
             void setup() override;
             void loop() override;
-            bool publish(DynamicJsonDocument &json) override;
 
             /**
              * @brief Get a status report.
@@ -36,12 +57,12 @@ namespace grmcdorman::device
             virtual String get_status() const;
 
         private:
+            void set_timer();                   //<! Set up ticker timer.
+
             SHT31 sht;
-            float temperature_sum = 0.0;        //!< The sum of all temperature readings since the last publish.
-            float humidity_sum = 0.0;           //!< The sum of all humidity readings since the last publish.
-            uint32_t reading_count = 0;         //!< The number of reads performed since the last publish.
-            float last_temperature = -273;      //!< Last read temperature. Initialized to 0 Kelvin, which we are rather unlikely to see.
-            float last_humidity = 0.0;          //!< Last read humidity.
+            Ticker ticker;                      //<! Ticker to handle readings.
+            uint32_t current_polling_seconds = 0;//<! Current polling interval.
+
             uint32_t last_read_millis;          //!< Timestamp of last read.
             bool requested = false;             //!< Whether a reading was requested.
             bool available = false;             //!< Whether the device is available.

--- a/src/grmcdorman/device/Sht31Sensor.h
+++ b/src/grmcdorman/device/Sht31Sensor.h
@@ -57,11 +57,11 @@ namespace grmcdorman::device
             virtual String get_status() const;
 
         private:
-            void set_timer();                   //<! Set up ticker timer.
+            void set_timer();                   //!< Set up ticker timer.
 
             SHT31 sht;
-            Ticker ticker;                      //<! Ticker to handle readings.
-            uint32_t current_polling_seconds = 0;//<! Current polling interval.
+            Ticker ticker;                      //!< Ticker to handle readings.
+            uint32_t current_polling_seconds = 0;//!< Current polling interval.
 
             uint32_t last_read_millis;          //!< Timestamp of last read.
             bool requested = false;             //!< Whether a reading was requested.

--- a/src/grmcdorman/device/SystemDetailsDisplay.h
+++ b/src/grmcdorman/device/SystemDetailsDisplay.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 
@@ -50,17 +72,7 @@ namespace grmcdorman::device
             void loop() override
             {
             }
-            /**
-             * @brief Publish to MQTT.
-             *
-             * This class does not publish to MQTT.
-             * @param json  Not used.
-             * @return `false`  No data published.
-             */
-            bool publish(DynamicJsonDocument &json) override
-            {
-                return false;
-            }
+            DynamicJsonDocument as_json() const override;
         private:
             InfoSettingHtml firmware_name;                  //!< Firmware identifier, as set by the system.
             InfoSettingHtml compile_datetime;               //!< Compile date and time.

--- a/src/grmcdorman/device/ThermistorSensor.h
+++ b/src/grmcdorman/device/ThermistorSensor.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+#include "grmcdorman/device/AbstractAnalog.h"
+#include "grmcdorman/Setting.h"
+
+namespace grmcdorman::device
+{
+    /**
+     * @brief A thermistor analog device.
+     *
+     * This device reads A0 and transforms the reading
+     * according to the standard thermistor properties
+     * to get a reading in degrees Celcius.
+     *
+     * Scaling can be applied to the reading after conversion
+     * to Celcius; this can be used to transform to other scales,
+     * such as Fahrenheit, or to correct inaccuracies. To convert
+     * to Fahrenheit, set the scale to 1.8 (9/5) and the offset to +32.
+     *
+     * The calculations make the following assumptions:
+     * - The ADC maximum value, 1023, corresponds to the +V supplied to the thermistor; i.e. the reference voltage and ADC voltage source are the same.
+     * - The resistor in series with the thermistor has a value close to the thermistor's resistance.
+     * - The thermistor is connected between the GND and the resistor.
+     *
+     * In other words, if your ESP8266 reads 1023 or 1024 for +3.3V, and your thermistor has a nominal resistance of
+     * 10K ohms at about 20 Celcius, then connect a 10K resistor in series with the thermistor between
+     * +3.3V and GND, and connect A0 to the junction of the thermistor and the resistor. In rough ASCII art:
+     * <pre>
+     *  [3.3V]------[10K resistor]------[thermistor]------[GND]
+     *                              |
+     *                             A0
+     * </pre>
+     *
+     * If your ADC does not have a maximum of 3.3V, then use a voltage divider to supply the ADC
+     * maximum - probably 1V - to the resistor.
+
+     * Thermistors have three parameters:
+     * - Thermal index (or Beta)
+     * - Calibration temperature, or T1, in Kelvin
+     * - Nominal resistance at T1, R.
+     *
+     * For example, I have a thermistor with B of 3950, R of 10k, and T1 of 25C, or (273.15+25)=298.15K.
+     *
+     * Only the thermal index (beta) and T1 value are needed.
+     *
+     * When publishing to MQTT, only the last reading is published, not the average reading over the interval.
+     */
+    class ThermistorSensor: public AbstractAnalog
+    {
+        public:
+            /**
+             * @brief Construct a new ThermistorSensor object.
+             *
+             * @param thermalIndex          The thermal index of the thermistor, e.g. 3950.
+             * @param t1Kelvin              The T1 temperature of the thermistor in Kelvin, e.g. 298.15 (25C).
+             */
+            ThermistorSensor(float thermalIndex, float t1Kelvin);
+
+            DynamicJsonDocument as_json() const override;
+
+            /**
+             * @brief Get a status report.
+             *
+             * This is also used for the `device_status` info message, with the exception
+             * of various disabled states.
+             *
+             * @return String containing status report.
+             */
+            virtual String get_status() const;
+        protected:
+            /**
+             * @brief Transform the raw reading to a temperature.
+             *
+             * The parameters from the constructor, and the assumptions about the wiring,
+             * are used to compute the temperature.
+             *
+             * @param reading   Raw reading.
+             * @return Temperature, in degrees C.
+             */
+            virtual float transform_raw_reading(int reading) override;
+            float inverse_thermal_index;        //<! The inverse of thermal index of the thermistor.
+            float inverse_t1;                   //<! The inverse of the T1 temperature of the thermistor.
+            NoteSetting title;                  //!< Device tab title.
+            InfoSettingHtml device_status;      //!< Last update
+    };
+}

--- a/src/grmcdorman/device/ThermistorSensor.h
+++ b/src/grmcdorman/device/ThermistorSensor.h
@@ -102,8 +102,8 @@ namespace grmcdorman::device
              * @return Temperature, in degrees C.
              */
             virtual float transform_raw_reading(int reading) override;
-            float inverse_thermal_index;        //<! The inverse of thermal index of the thermistor.
-            float inverse_t1;                   //<! The inverse of the T1 temperature of the thermistor.
+            float inverse_thermal_index;        //!< The inverse of thermal index of the thermistor.
+            float inverse_t1;                   //!< The inverse of the T1 temperature of the thermistor.
             NoteSetting title;                  //!< Device tab title.
             InfoSettingHtml device_status;      //!< Last update
     };

--- a/src/grmcdorman/device/WebServerRestAPI.h
+++ b/src/grmcdorman/device/WebServerRestAPI.h
@@ -42,29 +42,30 @@ namespace grmcdorman::device
     public:
         WebServerRestApi();
         /**
-         * @brief Set defaults.
+         * @brief Set up with the web server.
          *
+         * This must be called after the devices have been added. The
+         * URIs for the devices, and the device list URI, will be registered with
+         * the server.
          *
+         * The URIs added are:
+         * - `/rest/devices/get` to return all devices
+         * - `/rest/device/`_device-id_`/get` to return values for one device
+         *
+         * @param server    Web server to install API on.
+         * @param devices   List of devices to install end-points for. A reference is held to this; this list must exist for the lifetime of this object.
          */
-        void set_defaults();
+        void setup(AsyncWebServer &server, const std::vector<Device *> &devices);
 
-        void setup(AsyncWebServer &server);
-
-        /**
-         * @brief Add the devices to serve
-         *
-         * This must be called before `setup`, so the appropriate APIs
-         * can be constructed.
-         *
-         * @param list  List of devices to manage.
-         */
-        void set_devices(const std::vector<Device *> &list)
-        {
-            devices = &list;
-        }
     private:
+        /**
+         * @brief Handle a device-specific GET.
+         *
+         * This handles the URI `/rest/device/`_device-id_`/get`.
+         *
+         * @param request   Incoming web request.
+         * @param device    Device associated with URI.
+         */
         void handle_on_device_get(AsyncWebServerRequest *request, const Device *device);
-
-        const std::vector<Device *> *devices;
     };
 }

--- a/src/grmcdorman/device/WebServerRestAPI.h
+++ b/src/grmcdorman/device/WebServerRestAPI.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "grmcdorman/device/Device.h"
+
+class AsyncWebServer;
+class AsyncWebServerRequest;
+
+namespace grmcdorman::device
+{
+    class Device;
+
+    /**
+     * @brief This class provides a REST API for the attached devices.
+     *
+     * This leverages the `Definitions` list in the Devices to create the API end points,
+     * and the `publish` method to serve requests.
+     */
+    class WebServerRestApi
+    {
+    public:
+        WebServerRestApi();
+        /**
+         * @brief Set defaults.
+         *
+         *
+         */
+        void set_defaults();
+
+        void setup(AsyncWebServer &server);
+
+        /**
+         * @brief Add the devices to serve
+         *
+         * This must be called before `setup`, so the appropriate APIs
+         * can be constructed.
+         *
+         * @param list  List of devices to manage.
+         */
+        void set_devices(const std::vector<Device *> &list)
+        {
+            devices = &list;
+        }
+    private:
+        void handle_on_device_get(AsyncWebServerRequest *request, const Device *device);
+
+        const std::vector<Device *> *devices;
+    };
+}

--- a/src/grmcdorman/device/WifiDisplay.h
+++ b/src/grmcdorman/device/WifiDisplay.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 
@@ -38,17 +60,7 @@ namespace grmcdorman::device
             void loop() override
             {
             }
-            /**
-             * @brief Publish to MQTT.
-             *
-             * This class does not publish to MQTT.
-             * @param json  Not used.
-             * @return `false`  No data published.
-             */
-            bool publish(DynamicJsonDocument &json) override
-            {
-                return false;
-            }
+            DynamicJsonDocument as_json() const override;
         private:
             NoteSetting title;                              //!< The panel title. Includes script for panel updating.
             InfoSettingHtml access_point_ip;

--- a/src/grmcdorman/device/WifiSetup.h
+++ b/src/grmcdorman/device/WifiSetup.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2022 G. R. McDorman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include "grmcdorman/device/Device.h"
@@ -36,8 +58,8 @@ namespace grmcdorman::device
             void set_defaults() override;
             void setup() override;
             void loop() override;
-            bool publish(DynamicJsonDocument &json) override;
-
+            bool publish(DynamicJsonDocument &json) const override;
+            DynamicJsonDocument as_json() const override;
             /**
              * @brief Get the local host name.
              *
@@ -49,7 +71,18 @@ namespace grmcdorman::device
             {
                 return hostname.get();
             }
-
+            /**
+             * @brief Get whether the device readings have been published.
+             *
+             * The WiFiSetup device always returns the current RSSI value. It
+             * is not averaged and as such should always be considered as
+             * "not published".
+             * @return false    Always publish RSSI.
+             */
+            bool get_is_published() const override
+            {
+                return false;
+            }
         private:
             void connect_to_ap();                           //!< Try to connect to the configured AP.
             StringSetting hostname;                         //!< The local host name configuration.


### PR DESCRIPTION
Three new devices:
* Basic analog; a generic ADC (analog to digital converter) sensor. Collects and publishes readings from the A0 connection.
* DHT: A DHT11/DHT22 sensor. Uses https://github.com/bertmelis/DHT for the DHT library (an interrupt-driven variant).
* Thermistor: An ADC sensor coded for use with a thermistor; readings are reported in degrees Celsius.

Improvements to all devices
* All devices now report a rolling average using the last 5 readings, instead of the average since the last MQTT publish (which can be a variable number of samples, and if your MQTT is offline it'd be far too many readings).
* Some commonality has been moved to base classes.
* MQTT publish data includes average, last read value, number of samples used for the average (up to 5), and the sample age, in milliseconds, at the time of publish.

New feature:
* An optional lightweight REST API server that provides a way to get device values in JSON.

New examples:
* BasicAnalogExample, for the BasicAnalog device.
* DhtSensorExample for the DhtSensor device.
* DhtSensorWithLCDExample for the DhtSensor with an I2C 16x2 LCD display.
* RestApiExample for the REST API server feature.
* RestClientWithLCDExample for a REST client with an I2C 16x2 LCD display.
* ThermistorExample for the Thermistor device.

Other changes:
* Switched to using Ticker for most timing.
* Copyright notice added to all files.
